### PR TITLE
Fix OB1 error

### DIFF
--- a/src/S3Commands.cc
+++ b/src/S3Commands.cc
@@ -388,7 +388,7 @@ AmazonS3Download::~AmazonS3Download() { }
 bool AmazonS3Download::SendRequest( off_t offset, size_t size ) {
 	if( offset != 0 || size != 0 ) {
 		std::string range;
-		formatstr( range, "bytes=%zu-%zu", offset, offset + size );
+		formatstr( range, "bytes=%zu-%zu", offset, offset + size -1 );
 		headers["Range"] = range.c_str();
 		this->expectedResponseCode = 206;
 	}


### PR DESCRIPTION
The range header was malformed, causing objects that didn't fit in a single buffer to fail on GET.