### PR TITLE
Simple cleanups of the S3/HTTP backend code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,8 +46,8 @@ endif()
 
 include_directories(${XROOTD_INCLUDES} ${CURL_INCLUDE_DIRS} ${LIBCRYPTO_INCLUDE_DIRS})
 
-add_library(XrdS3 SHARED src/S3File.cc src/S3FileSystem.cc src/AWSv4-impl.cc src/S3Commands.cc src/HTTPCommands.cc src/stl_string_utils.cc src/shortfile.cc)
-add_library(XrdHTTPServer SHARED src/HTTPFile.cc src/HTTPFileSystem.cc src/HTTPCommands.cc src/stl_string_utils.cc src/shortfile.cc)
+add_library(XrdS3 SHARED src/S3File.cc src/S3FileSystem.cc src/AWSv4-impl.cc src/S3Commands.cc src/HTTPCommands.cc src/stl_string_utils.cc src/shortfile.cc src/logging.cc)
+add_library(XrdHTTPServer SHARED src/HTTPFile.cc src/HTTPFileSystem.cc src/HTTPCommands.cc src/stl_string_utils.cc src/shortfile.cc src/logging.cc)
 
 target_link_libraries(XrdS3 -ldl ${XROOTD_UTILS_LIB} ${XROOTD_SERVER_LIB} ${CURL_LIBRARIES} ${LIBCRYPTO_LIBRARIES})
 target_link_libraries(XrdHTTPServer -ldl ${XROOTD_UTILS_LIB} ${XROOTD_SERVER_LIB} ${CURL_LIBRARIES} ${LIBCRYPTO_LIBRARIES})

--- a/src/AWSCredential.hh
+++ b/src/AWSCredential.hh
@@ -1,5 +1,21 @@
-#ifndef AWS_CREDENTIAL_H
-#define AWS_CREDENTIAL_H
+/***************************************************************
+ *
+ * Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+#pragma once
 
 class AWSCredential {
 
@@ -19,5 +35,3 @@ class AWSCredential {
         const std::string m_secret_key;
         const std::string m_security_token;
 };
-
-#endif /* AWS_CREDENTIAL_H */

--- a/src/AWSv4-impl.cc
+++ b/src/AWSv4-impl.cc
@@ -100,7 +100,7 @@ convertMessageDigestToLowercaseHex(
 	char * buffer = (char *)malloc( (mdLength * 2) + 1 );
 	char * ptr = buffer;
 	for (unsigned int i = 0; i < mdLength; ++i, ptr += 2) {
-		snprintf(ptr, 2, "%02x", messageDigest[i]);
+		snprintf(ptr, 3, "%02x", messageDigest[i]);
 	}
 	hexEncoded.assign(buffer, mdLength * 2);
 	free(buffer);

--- a/src/AWSv4-impl.cc
+++ b/src/AWSv4-impl.cc
@@ -1,3 +1,21 @@
+/***************************************************************
+ *
+ * Copyright (C) 2023, HTCondor team, UW-Madison
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
 /**
  * Utilities for generating pre-signed URLs.
  *
@@ -82,7 +100,7 @@ convertMessageDigestToLowercaseHex(
 	char * buffer = (char *)malloc( (mdLength * 2) + 1 );
 	char * ptr = buffer;
 	for (unsigned int i = 0; i < mdLength; ++i, ptr += 2) {
-		sprintf(ptr, "%02x", messageDigest[i]);
+		snprintf(ptr, 2, "%02x", messageDigest[i]);
 	}
 	hexEncoded.assign(buffer, mdLength * 2);
 	free(buffer);

--- a/src/AWSv4-impl.hh
+++ b/src/AWSv4-impl.hh
@@ -1,5 +1,25 @@
-#ifndef AWSV4_IMPL_H
-#define AWSV4_IMPL_H
+/***************************************************************
+ *
+ * Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+#pragma once
+
+#include <map>
+#include <string>
 
 namespace AWSv4Impl {
 
@@ -27,5 +47,3 @@ createSignature( const std::string & secretAccessKey,
     std::string & signature );
 
 }
-
-#endif /* AWSV4_IMPL_H */

--- a/src/HTTPCommands.cc
+++ b/src/HTTPCommands.cc
@@ -430,7 +430,7 @@ HTTPUpload::~HTTPUpload() { }
 bool HTTPUpload::SendRequest( const std::string & payload, off_t offset, size_t size ) {
 	if( offset != 0 || size != 0 ) {
 		std::string range;
-		formatstr( range, "bytes=%lld-%lld", offset, offset + size - 1 );
+		formatstr( range, "bytes=%lld-%lld", static_cast<long long int>(offset), static_cast<long long int>(offset + size - 1));
 		headers["Range"] = range.c_str();
 	}
 
@@ -445,7 +445,7 @@ HTTPDownload::~HTTPDownload() { }
 bool HTTPDownload::SendRequest( off_t offset, size_t size ) {
 	if( offset != 0 || size != 0 ) {
 		std::string range;
-		formatstr( range, "bytes=%lld-%lld", offset, offset + size - 1 );
+		formatstr( range, "bytes=%lld-%lld", static_cast<long long int>(offset), static_cast<long long int>(offset + size - 1));
 		headers["Range"] = range.c_str();
 		this->expectedResponseCode = 206;
 	}

--- a/src/HTTPCommands.hh
+++ b/src/HTTPCommands.hh
@@ -1,17 +1,40 @@
-#ifndef HTTP_COMMANDS_H
-#define HTTP_COMMANDS_H
+/***************************************************************
+ *
+ * Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
 
+#pragma once
+
+#include <map>
+#include <string>
+
+class XrdSysError;
 
 class HTTPRequest {
 public:
     HTTPRequest(
-        const std::string & hostUrl
+        const std::string & hostUrl,
+        XrdSysError &log
     ) :
     hostUrl(hostUrl),
     requiresSignature(false),
     responseCode(0),
     includeResponseHeader(false),
-    httpVerb( "POST" )
+    httpVerb("POST"),
+    m_log(log)
     { 
         // Parse the URL and populate
         // What to do if the function returns false?
@@ -60,15 +83,18 @@ protected:
     bool includeResponseHeader;
 
     std::string httpVerb;
+
+    XrdSysError &m_log;
 };
 
 class HTTPUpload : public HTTPRequest {
 public:
     HTTPUpload(
         const std::string & h,
-        const std::string & o
+        const std::string & o,
+        XrdSysError &log
     ) :
-        HTTPRequest(h),
+        HTTPRequest(h, log),
         object(o)
     { hostUrl = hostUrl + "/" + object; }
 
@@ -85,9 +111,10 @@ class HTTPDownload : public HTTPRequest {
 public:
     HTTPDownload(
         const std::string & h,
-        const std::string & o
+        const std::string & o,
+        XrdSysError &log
     ) :
-        HTTPRequest(h),
+        HTTPRequest(h, log),
         object(o)
     { hostUrl = hostUrl + "/" + object; }
 
@@ -103,9 +130,10 @@ class HTTPHead : public HTTPRequest {
 public:
     HTTPHead(
         const std::string & h,
-        const std::string & o
+        const std::string & o,
+        XrdSysError &log
     ) :
-        HTTPRequest(h),
+        HTTPRequest(h, log),
         object(o)
     { hostUrl = hostUrl + "/" + object; }
 
@@ -116,5 +144,3 @@ public:
 protected:
     std::string object;
 };
-
-#endif /* HTTP_COMMANDS_H */

--- a/src/HTTPDirectory.hh
+++ b/src/HTTPDirectory.hh
@@ -1,8 +1,27 @@
+/***************************************************************
+ *
+ * Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
 #pragma once
 
 #include "XrdOuc/XrdOucEnv.hh"
 #include "XrdOss/XrdOss.hh"
 
+class XrdSysError;
 
 class HTTPDirectory : public XrdOssDF {
 public:
@@ -20,21 +39,21 @@ public:
         return -ENOSYS;
     }
 
-    virtual int Readdir(char *buff, int blen)
+    virtual int Readdir(char *buff, int blen) override
     {
         return -ENOSYS;
     }
 
-    virtual int StatRet(struct stat *statStruct)
+    virtual int StatRet(struct stat *statStruct) override
     {
         return -ENOSYS;
     }
 
-    virtual int Close(long long *retsz=0)
+    virtual int Close(long long *retsz=0) override
     {
         return -ENOSYS;
     }
 
 protected:
-    XrdSysError m_log;
+    XrdSysError &m_log;
 };

--- a/src/HTTPFile.hh
+++ b/src/HTTPFile.hh
@@ -1,3 +1,21 @@
+/***************************************************************
+ *
+ * Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
 #pragma once
 
 #include "XrdOuc/XrdOucEnv.hh"
@@ -111,7 +129,7 @@ public:
         return -ENOSYS;
     }
 
-    virtual int Close(long long *retsz=0); // upstream is abstract definition
+    virtual int Close(long long *retsz=0) override; // upstream is abstract definition
 
     size_t getContentLength() { return content_length; }
     time_t getLastModified() { return last_modified; }

--- a/src/HTTPFileSystem.hh
+++ b/src/HTTPFileSystem.hh
@@ -1,9 +1,27 @@
+/***************************************************************
+ *
+ * Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
 #pragma once
 
-#include "XrdOuc/XrdOucStream.hh"
-#include "XrdSec/XrdSecEntity.hh"
-#include "XrdVersion.hh"
-#include "XrdOss/XrdOss.hh"
+#include <XrdOss/XrdOss.hh>
+#include <XrdOuc/XrdOucStream.hh>
+#include <XrdSec/XrdSecEntity.hh>
+#include <XrdVersion.hh>
 
 #include <memory>
 #include <string>

--- a/src/S3Commands.cc
+++ b/src/S3Commands.cc
@@ -397,7 +397,7 @@ AmazonS3Upload::~AmazonS3Upload() { }
 bool AmazonS3Upload::SendRequest( const std::string & payload, off_t offset, size_t size ) {
 	if( offset != 0 || size != 0 ) {
 		std::string range;
-		formatstr(range, "bytes=%lld-%lld", offset, offset + size - 1);
+		formatstr(range, "bytes=%lld-%lld", static_cast<long long int>(offset), static_cast<long long int>(offset + size - 1));
 		headers["Range"] = range.c_str();
 	}
 
@@ -412,7 +412,7 @@ AmazonS3Download::~AmazonS3Download() { }
 bool AmazonS3Download::SendRequest( off_t offset, size_t size ) {
 	if( offset != 0 || size != 0 ) {
 		std::string range;
-		formatstr(range, "bytes=%lld-%lld", offset, offset + size - 1);
+		formatstr(range, "bytes=%lld-%lld",static_cast<long long int>(offset), static_cast<long long int>(offset + size - 1));
 		headers["Range"] = range.c_str();
 		this->expectedResponseCode = 206;
 	}

--- a/src/S3Commands.cc
+++ b/src/S3Commands.cc
@@ -1,18 +1,37 @@
-#include <sstream>
-#include <algorithm>
+/***************************************************************
+ *
+ * Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+#include "AWSv4-impl.hh"
+#include "S3Commands.hh"
+#include "shortfile.hh"
+#include "stl_string_utils.hh"
+
 #include <openssl/hmac.h>
 #include <curl/curl.h>
+#include <XrdSys/XrdSysError.hh>
+
+#include <algorithm>
 #include <cassert>
 #include <cstring>
-#include <memory>
-
 #include <map>
+#include <memory>
+#include <sstream>
 #include <string>
-
-#include "S3Commands.hh"
-#include "AWSv4-impl.hh"
-#include "stl_string_utils.hh"
-#include "shortfile.hh"
 
 AmazonRequest::~AmazonRequest() { }
 
@@ -378,7 +397,7 @@ AmazonS3Upload::~AmazonS3Upload() { }
 bool AmazonS3Upload::SendRequest( const std::string & payload, off_t offset, size_t size ) {
 	if( offset != 0 || size != 0 ) {
 		std::string range;
-		formatstr( range, "bytes=%zu-%zu", offset, offset + size - 1 );
+		formatstr(range, "bytes=%lld-%lld", offset, offset + size - 1);
 		headers["Range"] = range.c_str();
 	}
 
@@ -393,7 +412,7 @@ AmazonS3Download::~AmazonS3Download() { }
 bool AmazonS3Download::SendRequest( off_t offset, size_t size ) {
 	if( offset != 0 || size != 0 ) {
 		std::string range;
-		formatstr( range, "bytes=%zu-%zu", offset, offset + size -1 );
+		formatstr(range, "bytes=%lld-%lld", offset, offset + size - 1);
 		headers["Range"] = range.c_str();
 		this->expectedResponseCode = 206;
 	}

--- a/src/S3Commands.hh
+++ b/src/S3Commands.hh
@@ -1,7 +1,26 @@
-#ifndef S3_COMMANDS_H
-#define S3_COMMANDS_H
+/***************************************************************
+ *
+ * Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+#pragma once
 
 #include "HTTPCommands.hh"
+
+#include <string>
 
 class AmazonRequest : public HTTPRequest {
 public:
@@ -12,9 +31,10 @@ public:
         const std::string & b,
         const std::string & o,
         const std::string & style,
-        int sv = 4
+        int sv,
+        XrdSysError &log
     ) :
-    HTTPRequest( s ),
+    HTTPRequest(s, log),
     accessKeyFile(akf),
     secretKeyFile(skf),
     signatureVersion(sv),
@@ -98,9 +118,10 @@ public:
         const std::string & skf,
         const std::string & b,
         const std::string & o,
-        const std::string & style
+        const std::string & style,
+        XrdSysError &log
     ) :
-    AmazonRequest(s, akf, skf, b, o, style){}
+        AmazonRequest(s, akf, skf, b, o, style, 4, log) {}
 
     virtual ~AmazonS3Upload();
 
@@ -119,9 +140,10 @@ public:
         const std::string & skf,
         const std::string & b,
         const std::string & o,
-        const std::string & style
+        const std::string & style,
+        XrdSysError &log
     ) :
-    AmazonRequest(s, akf, skf, b, o, style){}
+    AmazonRequest(s, akf, skf, b, o, style, 4, log){}
 
     virtual ~AmazonS3Download();
 
@@ -137,13 +159,12 @@ public:
         const std::string & skf,
         const std::string & b,
         const std::string & o,
-        const std::string & style
+        const std::string & style,
+        XrdSysError &log
     ) :
-    AmazonRequest(s, akf, skf, b, o, style){}
+    AmazonRequest(s, akf, skf, b, o, style, 4, log){}
 
     virtual ~AmazonS3Head();
 
     virtual bool SendRequest();
 };
-
-#endif /* S3_COMMANDS_H */

--- a/src/S3Directory.hh
+++ b/src/S3Directory.hh
@@ -1,7 +1,24 @@
+/***************************************************************
+ *
+ * Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
 #pragma once
 
 #include "HTTPDirectory.hh"
-
 
 // Leaving in duplicate definitions for now. It remains
 // to be seen if we'll need to change these and have specific

--- a/src/S3File.hh
+++ b/src/S3File.hh
@@ -1,11 +1,30 @@
+/***************************************************************
+ *
+ * Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
 #pragma once
 
-#include "XrdOuc/XrdOucEnv.hh"
-#include "XrdSec/XrdSecEntity.hh"
-#include "XrdSec/XrdSecEntityAttr.hh"
-#include "XrdVersion.hh"
-#include "XrdOss/XrdOss.hh"
 #include "S3FileSystem.hh"
+
+#include <XrdOuc/XrdOucEnv.hh>
+#include <XrdOss/XrdOss.hh>
+#include <XrdSec/XrdSecEntity.hh>
+#include <XrdSec/XrdSecEntityAttr.hh>
+#include <XrdVersion.hh>
 
 #include <memory>
 
@@ -111,7 +130,7 @@ public:
         return -ENOSYS;
     }
 
-    int Close(long long *retsz=0);
+    int Close(long long *retsz=0) override;
 
     size_t getContentLength() { return content_length; }
     time_t getLastModified() { return last_modified; }

--- a/src/S3FileSystem.cc
+++ b/src/S3FileSystem.cc
@@ -1,22 +1,39 @@
-#include "XrdOuc/XrdOucEnv.hh"
-#include "XrdOuc/XrdOucStream.hh"
-#include "XrdSec/XrdSecEntity.hh"
-#include "XrdVersion.hh"
-#include "S3FileSystem.hh"
+/***************************************************************
+ *
+ * Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
 #include "S3Directory.hh"
 #include "S3File.hh"
+#include "S3FileSystem.hh"
 #include "stl_string_utils.hh"
 
+#include <XrdOuc/XrdOucEnv.hh>
+#include <XrdOuc/XrdOucStream.hh>
+#include <XrdSec/XrdSecEntity.hh>
+#include <XrdVersion.hh>
+
 #include <memory>
-#include <vector>
 #include <stdexcept>
+#include <vector>
 
 #include <fcntl.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
-
-#include "stl_string_utils.hh"
 
 S3FileSystem::S3FileSystem(XrdSysLogger *lp, const char *configfn, XrdOucEnv *envP) :
     m_env(envP),

--- a/src/S3FileSystem.hh
+++ b/src/S3FileSystem.hh
@@ -1,9 +1,27 @@
+/***************************************************************
+ *
+ * Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
 #pragma once
 
-#include "XrdOuc/XrdOucStream.hh"
-#include "XrdSec/XrdSecEntity.hh"
-#include "XrdVersion.hh"
-#include "XrdOss/XrdOss.hh"
+#include <XrdOuc/XrdOucStream.hh>
+#include <XrdSec/XrdSecEntity.hh>
+#include <XrdVersion.hh>
+#include <XrdOss/XrdOss.hh>
 
 #include <memory>
 #include <string>

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -1,0 +1,73 @@
+/***************************************************************
+ *
+ * Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+#include "logging.hh"
+
+#include <XrdOuc/XrdOucStream.hh>
+#include <XrdSys/XrdSysError.hh>
+
+#include <sstream>
+
+using namespace XrdHTTPServer;
+
+std::string
+XrdHTTPServer::LogMaskToString(int mask) {
+    if (mask == LogMask::All) {return "all";}
+        
+    bool has_entry = false;
+    std::stringstream ss;
+    if (mask & LogMask::Debug) {
+        ss << "debug"; 
+        has_entry = true;
+    }           
+    if (mask & LogMask::Info) {
+        ss << (has_entry ? ", " : "") << "info";
+        has_entry = true;
+    }       
+    if (mask & LogMask::Warning) {
+        ss << (has_entry ? ", " : "") << "warning";
+        has_entry = true;
+    }   
+    if (mask & LogMask::Error) {
+        ss << (has_entry ? ", " : "") << "error";
+        has_entry = true;
+    }   
+    return ss.str();
+}
+
+bool
+XrdHTTPServer::ConfigLog(XrdOucStream &conf, XrdSysError &log) {
+        std::string map_filename;
+        log.setMsgMask(0);
+        char *val = nullptr;
+        if (!(val = conf.GetToken())) {
+            log.Emsg("Config", "httpserver.trace requires an argument.  Usage: httpserver.trace [all|error|warning|info|debug|none]");
+            return false;
+        }
+        do {
+            if (!strcmp(val, "all")) {log.setMsgMask(log.getMsgMask() | LogMask::All);}
+            else if (!strcmp(val, "error")) {log.setMsgMask(log.getMsgMask() | LogMask::Error);}
+            else if (!strcmp(val, "warning")) {log.setMsgMask(log.getMsgMask() | LogMask::Warning);}
+            else if (!strcmp(val, "info")) {log.setMsgMask(log.getMsgMask() | LogMask::Info);}
+            else if (!strcmp(val, "debug")) {log.setMsgMask(log.getMsgMask() | LogMask::Debug);}
+            else if (!strcmp(val, "none")) {log.setMsgMask(0);}
+            else {log.Emsg("Config", "scitokens.trace encountered an unknown directive:", val); return false;}
+        } while ((val = conf.GetToken()));
+        log.Emsg("Config", "Logging levels enabled -", XrdHTTPServer::LogMaskToString(log.getMsgMask()).c_str());
+    return true;
+}

--- a/src/logging.hh
+++ b/src/logging.hh
@@ -1,6 +1,6 @@
 /***************************************************************
  *
- * Copyright (C) 2024, HTCondor Team, UW-Madison
+ * Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you
  * may not use this file except in compliance with the License.  You may
@@ -20,17 +20,24 @@
 
 #include <string>
 
-#ifndef CHECK_PRINTF_FORMAT
-    #ifdef __GNUC__
-        #define CHECK_PRINTF_FORMAT(a,b) __attribute__((__format__(__printf__, a, b)))
-    #else
-        #define CHECK_PRINTF_FORMAT(a,b)
-    #endif
-#endif
+class XrdOucStream;
+class XrdSysError;
 
-void trim( std::string & str );
-std::string substring( const std::string & str, size_t left, size_t right = std::string::npos );
-void toLower( std::string & str);
+namespace XrdHTTPServer {
 
-int formatstr(std::string& s, const char* format, ...) CHECK_PRINTF_FORMAT(2,3);
-int formatstr_cat(std::string& s, const char* format, ...) CHECK_PRINTF_FORMAT(2,3);
+enum LogMask {  
+    Debug = 0x01,
+    Info = 0x02,
+    Warning = 0x04,
+    Error = 0x08,
+    All = 0xff  
+};          
+
+// Given a bitset based on LogMask, return a human-readable string of the set logging levels.
+std::string LogMaskToString(int mask);
+
+// Given an xrootd configuration object that matched on httpserver.trace, parse
+// the remainder of the line and configure the logger appropriately.
+bool ConfigLog(XrdOucStream &conf, XrdSysError &log);
+
+}

--- a/src/shortfile.cc
+++ b/src/shortfile.cc
@@ -1,11 +1,30 @@
+/***************************************************************
+ *
+ * Copyright (C) 2023, HTCondor Team, UW-Madison
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+#include "shortfile.hh"
+
+#include <string>
+
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <unistd.h>
 #include <cassert>
-
-#include <string>
-#include "shortfile.hh"
 
 
 ssize_t

--- a/src/shortfile.hh
+++ b/src/shortfile.hh
@@ -1,6 +1,23 @@
-#ifndef SHORTFILE_H
-#define SHORTFILE_H
+/***************************************************************
+ *
+ * Copyright (C) 2023, HTCondor Team, UW-Madison
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
 
-bool readShortFile( const std::string & fileName, std::string & contents );
+#pragma once
 
-#endif /* SHORTFILE_H */
+#include <string>
+
+bool readShortFile(const std::string &fileName, std::string &contents);

--- a/src/stl_string_utils.cc
+++ b/src/stl_string_utils.cc
@@ -1,9 +1,28 @@
-#include <stdarg.h>
-#include <cassert>
+/***************************************************************
+ *
+ * Copyright (C) 2024, HTCondor Team, UW-Madison
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
 
-#include <string>
-#include <algorithm>
 #include "stl_string_utils.hh"
+
+#include <algorithm>
+#include <cassert>
+#include <string>
+
+#include <stdarg.h>
 
 std::string
 substring( const std::string & str, size_t left, size_t right ) {


### PR DESCRIPTION
Includes:
- Adding copyright notices to each source file.
- Use XRootD's logging framework and corresponding configuration.
- Re-arrange/cleanup headers
- Fix all compilation warnings identified by Mac OS X's compiler.