### PR TITLE
Switch static variable to thread_local to fix underflow bug

### DIFF
--- a/src/HTTPCommands.cc
+++ b/src/HTTPCommands.cc
@@ -136,9 +136,7 @@ int debug_callback(CURL *, curl_infotype ci, char *data, size_t size, void *) {
 }
 
 size_t read_callback(char *buffer, size_t size, size_t n, void *v) {
-	// This can be static because only one curl_easy_perform() can be
-	// running at a time.
-	static size_t sentSoFar = 0;
+	thread_local size_t sentSoFar = 0;
 	std::string *payload = (std::string *)v;
 
 	if (sentSoFar == payload->size()) {


### PR DESCRIPTION
Multiple threads appear to be running through `read_callback` with their own data, and they're fighting over the `sentSoFar` variable. Switching it from static to thread_local makes sure each thread has its own copy to use.

I understand less about how XRootD manages threads, but making this switch appears to fix what was otherwise a guaranteed crash.