### PR TITLE
Token support for HTTP backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ set( CMAKE_BUILD_TYPE Debug )
 
 find_package( Xrootd REQUIRED )
 find_package( CURL REQUIRED )
+find_package( Threads REQUIRED )
 
 include (FindPkgConfig)
 pkg_check_modules(LIBCRYPTO REQUIRED libcrypto)
@@ -59,8 +60,8 @@ include_directories(${XROOTD_INCLUDES} ${CURL_INCLUDE_DIRS} ${LIBCRYPTO_INCLUDE_
 add_library(XrdS3 SHARED src/S3File.cc src/S3Directory.cc src/S3AccessInfo.cc src/S3FileSystem.cc src/AWSv4-impl.cc src/S3Commands.cc src/HTTPCommands.cc src/TokenFile.cc src/stl_string_utils.cc src/shortfile.cc src/logging.cc)
 add_library(XrdHTTPServer SHARED src/HTTPFile.cc src/HTTPFileSystem.cc src/HTTPCommands.cc src/TokenFile.cc src/stl_string_utils.cc src/shortfile.cc src/logging.cc)
 
-target_link_libraries(XrdS3 -ldl ${XROOTD_UTILS_LIB} ${XROOTD_SERVER_LIB} ${CURL_LIBRARIES} ${LIBCRYPTO_LIBRARIES} tinyxml2::tinyxml2)
-target_link_libraries(XrdHTTPServer -ldl ${XROOTD_UTILS_LIB} ${XROOTD_SERVER_LIB} ${CURL_LIBRARIES} ${LIBCRYPTO_LIBRARIES})
+target_link_libraries(XrdS3 -ldl ${XROOTD_UTILS_LIB} ${XROOTD_SERVER_LIB} ${CURL_LIBRARIES} ${LIBCRYPTO_LIBRARIES} tinyxml2::tinyxml2 Threads::Threads)
+target_link_libraries(XrdHTTPServer -ldl ${XROOTD_UTILS_LIB} ${XROOTD_SERVER_LIB} ${CURL_LIBRARIES} ${LIBCRYPTO_LIBRARIES} Threads::Threads)
 
 # The CMake documentation strongly advises against using these macros; instead, the pkg_check_modules
 # is supposed to fill out the full path to ${LIBCRYPTO_LIBRARIES}.  As of cmake 3.26.1, this does not

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,8 +56,8 @@ endif()
 
 include_directories(${XROOTD_INCLUDES} ${CURL_INCLUDE_DIRS} ${LIBCRYPTO_INCLUDE_DIRS})
 
-add_library(XrdS3 SHARED src/S3File.cc src/S3Directory.cc src/S3AccessInfo.cc src/S3FileSystem.cc src/AWSv4-impl.cc src/S3Commands.cc src/HTTPCommands.cc src/stl_string_utils.cc src/shortfile.cc src/logging.cc)
-add_library(XrdHTTPServer SHARED src/HTTPFile.cc src/HTTPFileSystem.cc src/HTTPCommands.cc src/stl_string_utils.cc src/shortfile.cc src/logging.cc)
+add_library(XrdS3 SHARED src/S3File.cc src/S3Directory.cc src/S3AccessInfo.cc src/S3FileSystem.cc src/AWSv4-impl.cc src/S3Commands.cc src/HTTPCommands.cc src/TokenFile.cc src/stl_string_utils.cc src/shortfile.cc src/logging.cc)
+add_library(XrdHTTPServer SHARED src/HTTPFile.cc src/HTTPFileSystem.cc src/HTTPCommands.cc src/TokenFile.cc src/stl_string_utils.cc src/shortfile.cc src/logging.cc)
 
 target_link_libraries(XrdS3 -ldl ${XROOTD_UTILS_LIB} ${XROOTD_SERVER_LIB} ${CURL_LIBRARIES} ${LIBCRYPTO_LIBRARIES} tinyxml2::tinyxml2)
 target_link_libraries(XrdHTTPServer -ldl ${XROOTD_UTILS_LIB} ${XROOTD_SERVER_LIB} ${CURL_LIBRARIES} ${LIBCRYPTO_LIBRARIES})

--- a/src/HTTPCommands.cc
+++ b/src/HTTPCommands.cc
@@ -341,6 +341,24 @@ bool HTTPRequest::sendPreparedRequest(const std::string &protocol,
 		}
 	}
 
+	if (m_token) {
+		const auto iter = headers.find("Authorization");
+		if (iter == headers.end()) {
+			std::string token;
+			if (m_token->Get(token) && !token.empty()) {
+				headers["Authorization"] = "Bearer " + token;
+			} else {
+				errorCode = "E_TOKEN";
+				errorMessage = "failed to load authorization token from file";
+			}
+		}
+	}
+	{
+		const auto iter = headers.find("User-Agent");
+		if (iter == headers.end()) {
+			headers["User-Agent"] = "xrootd-http/devel";
+		}
+	}
 	std::string headerPair;
 	struct curl_slist *header_slist = NULL;
 	for (auto i = headers.begin(); i != headers.end(); ++i) {

--- a/src/HTTPCommands.cc
+++ b/src/HTTPCommands.cc
@@ -168,12 +168,6 @@ bool HTTPRequest::sendPreparedRequest(const std::string &protocol,
 
 	m_log.Log(XrdHTTPServer::Debug, "SendRequest", "Sending HTTP request",
 			  uri.c_str());
-	CURLcode rv = curl_global_init(CURL_GLOBAL_ALL);
-	if (rv != 0) {
-		this->errorCode = "E_CURL_LIB";
-		this->errorMessage = "curl_global_init() failed.";
-		return false;
-	}
 
 	std::unique_ptr<CURL, decltype(&curl_easy_cleanup)> curl(
 		curl_easy_init(), &curl_easy_cleanup);
@@ -185,7 +179,7 @@ bool HTTPRequest::sendPreparedRequest(const std::string &protocol,
 	}
 
 	char errorBuffer[CURL_ERROR_SIZE];
-	rv = curl_easy_setopt(curl.get(), CURLOPT_ERRORBUFFER, errorBuffer);
+	auto rv = curl_easy_setopt(curl.get(), CURLOPT_ERRORBUFFER, errorBuffer);
 	if (rv != CURLE_OK) {
 		this->errorCode = "E_CURL_LIB";
 		this->errorMessage = "curl_easy_setopt( CURLOPT_ERRORBUFFER ) failed.";
@@ -446,6 +440,13 @@ bool HTTPUpload::SendRequest(const std::string &payload, off_t offset,
 
 	httpVerb = "PUT";
 	return SendHTTPRequest(payload);
+}
+
+void HTTPRequest::init() {
+	CURLcode rv = curl_global_init(CURL_GLOBAL_ALL);
+	if (rv != 0) {
+		throw std::runtime_error("libcurl failed to initialize");
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/src/HTTPCommands.hh
+++ b/src/HTTPCommands.hh
@@ -18,6 +18,8 @@
 
 #pragma once
 
+#include "TokenFile.hh"
+
 #include <map>
 #include <memory>
 #include <string>
@@ -26,9 +28,9 @@ class XrdSysError;
 
 class HTTPRequest {
   public:
-	HTTPRequest(const std::string &hostUrl, XrdSysError &log)
-		: hostUrl(hostUrl), requiresSignature(false), responseCode(0),
-		  includeResponseHeader(false), httpVerb("POST"), m_log(log) {
+	HTTPRequest(const std::string &hostUrl, XrdSysError &log,
+				const TokenFile *token)
+		: hostUrl(hostUrl), m_log(log), m_token(token) {
 		// Parse the URL and populate
 		// What to do if the function returns false?
 		// TODO: Figure out best way to deal with this
@@ -75,7 +77,7 @@ class HTTPRequest {
 	std::string hostUrl;
 	std::string protocol;
 
-	bool requiresSignature;
+	bool requiresSignature{false};
 	struct timespec signatureTime;
 
 	std::string errorMessage;
@@ -84,18 +86,22 @@ class HTTPRequest {
 	std::string resultString;
 	unsigned long responseCode{0};
 	unsigned long expectedResponseCode = 200;
-	bool includeResponseHeader;
+	bool includeResponseHeader{false};
 
-	std::string httpVerb;
+	std::string httpVerb{"POST"};
 	std::unique_ptr<HTTPRequest::Payload> callback_payload;
 
 	XrdSysError &m_log;
+
+  private:
+	const TokenFile *m_token;
 };
 
 class HTTPUpload : public HTTPRequest {
   public:
-	HTTPUpload(const std::string &h, const std::string &o, XrdSysError &log)
-		: HTTPRequest(h, log), object(o) {
+	HTTPUpload(const std::string &h, const std::string &o, XrdSysError &log,
+			   const TokenFile *token)
+		: HTTPRequest(h, log, token), object(o) {
 		hostUrl = hostUrl + "/" + object;
 	}
 
@@ -111,8 +117,9 @@ class HTTPUpload : public HTTPRequest {
 
 class HTTPDownload : public HTTPRequest {
   public:
-	HTTPDownload(const std::string &h, const std::string &o, XrdSysError &log)
-		: HTTPRequest(h, log), object(o) {
+	HTTPDownload(const std::string &h, const std::string &o, XrdSysError &log,
+				 const TokenFile *token)
+		: HTTPRequest(h, log, token), object(o) {
 		hostUrl = hostUrl + "/" + object;
 	}
 
@@ -126,8 +133,9 @@ class HTTPDownload : public HTTPRequest {
 
 class HTTPHead : public HTTPRequest {
   public:
-	HTTPHead(const std::string &h, const std::string &o, XrdSysError &log)
-		: HTTPRequest(h, log), object(o) {
+	HTTPHead(const std::string &h, const std::string &o, XrdSysError &log,
+			 const TokenFile *token)
+		: HTTPRequest(h, log, token), object(o) {
 		hostUrl = hostUrl + "/" + object;
 	}
 

--- a/src/HTTPCommands.hh
+++ b/src/HTTPCommands.hh
@@ -57,6 +57,12 @@ class HTTPRequest {
 		size_t sentSoFar;
 	};
 
+	// Initialize libraries for HTTP.
+	//
+	// Should be called at least once per application from a non-threaded
+	// context.
+	static void init();
+
   protected:
 	bool sendPreparedRequest(const std::string &protocol,
 							 const std::string &uri,

--- a/src/HTTPFile.cc
+++ b/src/HTTPFile.cc
@@ -256,6 +256,7 @@ XrdOss *XrdOssGetStorageSystem2(XrdOss *native_oss, XrdSysLogger *Logger,
 	envP->Export("XRDXROOTD_NOPOSC", "1");
 
 	try {
+		HTTPRequest::init();
 		g_http_oss = new HTTPFileSystem(Logger, config_fn, envP);
 		return g_http_oss;
 	} catch (std::runtime_error &re) {

--- a/src/HTTPFile.hh
+++ b/src/HTTPFile.hh
@@ -95,12 +95,14 @@ class HTTPFile : public XrdOssDF {
 	time_t getLastModified() { return last_modified; }
 
   private:
+	bool m_stat{false};
+
 	XrdSysError &m_log;
 	HTTPFileSystem *m_oss;
 
-	std::string hostname;
-	std::string hostUrl;
-	std::string object;
+	std::string m_hostname;
+	std::string m_hostUrl;
+	std::string m_object;
 
 	size_t content_length;
 	time_t last_modified;

--- a/src/HTTPFileSystem.cc
+++ b/src/HTTPFileSystem.cc
@@ -161,14 +161,7 @@ int HTTPFileSystem::Stat(const char *path, struct stat *buff, int opts,
 		m_log.Emsg("Stat", "Failed to open path:", path);
 	}
 	// Assume that HTTPFile::FStat() doesn't write to buff unless it succeeds.
-	rv = httpFile.Fstat(buff);
-	if (rv != 0) {
-		formatstr(error, "File %s not found.", path);
-		m_log.Emsg("Stat", error.c_str());
-		return -ENOENT;
-	}
-
-	return 0;
+	return httpFile.Fstat(buff);
 }
 
 int HTTPFileSystem::Create(const char *tid, const char *path, mode_t mode,

--- a/src/HTTPFileSystem.hh
+++ b/src/HTTPFileSystem.hh
@@ -18,9 +18,12 @@
 
 #pragma once
 
+#include "TokenFile.hh"
+
 #include <XrdOss/XrdOss.hh>
 #include <XrdOuc/XrdOucStream.hh>
 #include <XrdSec/XrdSecEntity.hh>
+#include <XrdSys/XrdSysPthread.hh>
 #include <XrdVersion.hh>
 
 #include <memory>
@@ -103,6 +106,7 @@ class HTTPFileSystem : public XrdOss {
 	const std::string &getHTTPHostUrl() const { return http_host_url; }
 	const std::string &getHTTPUrlBase() const { return m_url_base; }
 	const std::string &getStoragePrefix() const { return m_storage_prefix; }
+	const TokenFile *getToken() const { return &m_token; }
 
   protected:
 	XrdOucEnv *m_env;
@@ -117,4 +121,5 @@ class HTTPFileSystem : public XrdOss {
 	std::string http_host_url;
 	std::string m_url_base;
 	std::string m_storage_prefix;
+	TokenFile m_token;
 };

--- a/src/S3Commands.hh
+++ b/src/S3Commands.hh
@@ -37,7 +37,7 @@ class AmazonRequest : public HTTPRequest {
 				  const std::string &skf, const std::string &b,
 				  const std::string &o, const std::string &style, int sv,
 				  XrdSysError &log)
-		: HTTPRequest(s, log), accessKeyFile(akf), secretKeyFile(skf),
+		: HTTPRequest(s, log, nullptr), accessKeyFile(akf), secretKeyFile(skf),
 		  signatureVersion(sv), bucket(b), object(o), m_style(style) {
 		requiresSignature = true;
 		// Start off by parsing the hostUrl, which we use in conjunction with

--- a/src/S3Commands.hh
+++ b/src/S3Commands.hh
@@ -82,6 +82,8 @@ class AmazonRequest : public HTTPRequest {
 	virtual bool SendRequest();
 	virtual bool SendS3Request(const std::string &payload);
 
+	static void init() { HTTPRequest::init(); }
+
   protected:
 	bool sendV4Request(const std::string &payload, bool sendContentSHA = false);
 

--- a/src/S3File.cc
+++ b/src/S3File.cc
@@ -208,6 +208,7 @@ XrdOss *XrdOssGetStorageSystem2(XrdOss *native_oss, XrdSysLogger *Logger,
 	envP->Export("XRDXROOTD_NOPOSC", "1");
 
 	try {
+		AmazonRequest::init();
 		g_s3_oss = new S3FileSystem(Logger, config_fn, envP);
 		return g_s3_oss;
 	} catch (std::runtime_error &re) {

--- a/src/TokenFile.cc
+++ b/src/TokenFile.cc
@@ -1,0 +1,84 @@
+/***************************************************************
+ *
+ * Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+#include "TokenFile.hh"
+#include "logging.hh"
+#include "shortfile.hh"
+#include "stl_string_utils.hh"
+
+#include <sstream>
+
+using namespace std::chrono_literals;
+
+const std::chrono::steady_clock::duration TokenFile::m_token_expiry = 5s;
+
+// Retrieve the bearer token to use with HTTP requests
+//
+// Returns true on success and sets `token` to the value of
+// the bearer token to use.  If there were no errors - but no
+// token is to be used - token is set to the empty string.
+// Otherwise, returns false.
+bool TokenFile::Get(std::string &token) const {
+	if (m_token_file.empty()) {
+		token.clear();
+		return true;
+	}
+
+	XrdSysRWLockHelper lock(m_token_mutex.get(), true);
+	if (m_token_load_success) {
+		auto now = std::chrono::steady_clock::now();
+		if (now - m_last_token_load <= m_token_expiry) {
+			token = m_token_contents;
+			return true;
+		}
+	}
+	lock.UnLock();
+
+	// Upgrade to write lock - we will mutate the data structures.
+	lock.Lock(m_token_mutex.get(), false);
+	std::string contents;
+	if (!readShortFile(m_token_file, contents)) {
+		if (m_log) {
+			m_log->Log(
+				XrdHTTPServer::LogMask::Warning, "getAuthToken",
+				"Failed to read token authorization file:", strerror(errno));
+		}
+		m_token_load_success = false;
+		return false;
+	}
+	std::istringstream istream;
+	istream.str(contents);
+	m_last_token_load = std::chrono::steady_clock::now();
+	m_token_load_success = true;
+	for (std::string line; std::getline(istream, line);) {
+		trim(line);
+		if (line.empty()) {
+			continue;
+		}
+		if (line[0] == '#') {
+			continue;
+		}
+		m_token_contents = line;
+		token = m_token_contents;
+		return true;
+	}
+	// If there are no error reading the file but the file has no tokens, we
+	// assume this indicates no token should be used.
+	token = "";
+	return true;
+}

--- a/src/TokenFile.hh
+++ b/src/TokenFile.hh
@@ -1,0 +1,52 @@
+/***************************************************************
+ *
+ * Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+#pragma once
+
+#include <XrdSys/XrdSysLogger.hh>
+#include <XrdSys/XrdSysPthread.hh>
+
+#include <chrono>
+#include <string>
+
+// A class representing a bearer token found from a file on disk
+class TokenFile {
+  public:
+	TokenFile(std::string filename, XrdSysError *log)
+		: m_log(log), m_token_file(filename),
+		  m_token_mutex(new XrdSysRWLock()) {}
+
+	TokenFile(const TokenFile &) = delete;
+	TokenFile(TokenFile &&other) noexcept = default;
+	TokenFile &operator=(TokenFile &&other) noexcept = default;
+
+	bool Get(std::string &) const;
+
+  private:
+	mutable bool m_token_load_success{false};
+	XrdSysError *m_log;
+	std::string m_token_file; // Location of a file containing a bearer token
+							  // for auth'z.
+	mutable std::string m_token_contents; // Cached copy of the token itself.
+	mutable std::chrono::steady_clock::time_point
+		m_last_token_load; // Last time the token was loaded from disk.
+	static const std::chrono::steady_clock::duration m_token_expiry;
+	mutable std::unique_ptr<XrdSysRWLock>
+		m_token_mutex; // Note: when we move to C++17, convert to
+					   // std::shared_mutex
+};

--- a/src/TokenFile.hh
+++ b/src/TokenFile.hh
@@ -22,6 +22,7 @@
 #include <XrdSys/XrdSysPthread.hh>
 
 #include <chrono>
+#include <memory>
 #include <string>
 
 // A class representing a bearer token found from a file on disk

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,6 +7,7 @@ add_executable( s3-gtest s3_tests.cc
   ../src/S3FileSystem.cc
   ../src/shortfile.cc
   ../src/stl_string_utils.cc
+  ../src/TokenFile.cc
   ../src/HTTPCommands.cc
   ../src/S3Commands.cc
 )
@@ -16,6 +17,7 @@ add_executable( http-gtest http_tests.cc
   ../src/HTTPFileSystem.cc
   ../src/HTTPCommands.cc
   ../src/stl_string_utils.cc
+  ../src/TokenFile.cc
   ../src/shortfile.cc
   ../src/logging.cc
 )

--- a/test/http_tests.cc
+++ b/test/http_tests.cc
@@ -27,7 +27,7 @@ class TestHTTPRequest : public HTTPRequest {
 	XrdSysLogger log{};
 	XrdSysError err{&log, "TestS3CommandsLog"};
 
-	TestHTTPRequest(const std::string &url) : HTTPRequest(url, err) {}
+	TestHTTPRequest(const std::string &url) : HTTPRequest(url, err, nullptr) {}
 };
 
 TEST(TestHTTPParseProtocol, Test1) {


### PR DESCRIPTION
(Note: given the extensive infrastructure improvements in #35, I built this PR on top of #35.  Don't try to review this until after #35 is merged)

This PR adds support for adding a bearer token to requests made by the HTTPFileSystem OSS plugin.  When configured, all requests will be made with the token read from the configured file.

The file is reloaded every 5 seconds, meaning that a short-lived token can be used if the file is updated.