### PR TITLE
Correctly handle the case with trailing slash in the service URL

### DIFF
--- a/src/S3Commands.cc
+++ b/src/S3Commands.cc
@@ -100,10 +100,22 @@ bool AmazonRequest::parseURL(const std::string &url, std::string &bucket_path,
 
 	if (m_style == "path") {
 		host = substring(url, hostStartIdx, resourceStartIdx);
-		path = substring(url, resourceStartIdx) + "/" + bucket + "/" + object;
+		auto resourcePrefix = substring(url, resourceStartIdx);
+		if (resourcePrefix[resourcePrefix.size() - 1] == '/') {
+			resourcePrefix =
+				substring(resourcePrefix, 0, resourcePrefix.size() - 1);
+		}
+		if (bucket.empty()) {
+			path = resourcePrefix + object;
+			bucket_path = resourcePrefix + object.substr(0, object.find('/'));
+		} else {
+			path = resourcePrefix + "/" + bucket + "/" + object;
+			bucket_path = resourcePrefix + "/" + bucket;
+		}
 	} else {
 		host = bucket + "." + substring(url, hostStartIdx, resourceStartIdx);
 		path = substring(url, resourceStartIdx) + object;
+		bucket_path = "/";
 	}
 
 	return true;


### PR DESCRIPTION
The service URL could technically contain a resource.  E.g.,

```
https://foo.example.com/prefix
```

or simply

```
https://foo.example.com/
```

In this case, the code logic didn't handle bucket names correctly, generating invalid URLs for directory listings and stat's.

This fixes said logic and adds some simple regression test coverage.

Fixes issues with NCAR S3 origin not being able to perform HEAD requests.