### PR TITLE
Add unit test coverage for S3 upload

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ project( xrootd-http/s3 )
 
 option( XROOTD_PLUGINS_BUILD_UNITTESTS "Build the scitokens-cpp unit tests" OFF )
 option( XROOTD_PLUGINS_EXTERNAL_GTEST "Use an external/pre-installed copy of GTest" OFF )
+option( VALGRIND "Run select unit tests under valgrind" OFF )
 
 set( CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake )
 set( CMAKE_BUILD_TYPE Debug )
@@ -18,6 +19,10 @@ pkg_check_modules(LIBCRYPTO REQUIRED libcrypto)
 if(NOT XROOTD_PLUGIN_VERSION)
   exec_program(${XROOTD_BIN}/xrootd-config ARGS "--plugin-version" OUTPUT_VARIABLE XROOTD_PLUGIN_VERSION RETURN_VALUE RETVAR)
   set(XROOTD_PLUGIN_VERSION ${XROOTD_PLUGIN_VERSION} CACHE INTERNAL "")
+endif()
+
+if(VALGRIND)
+  find_program(VALGRIND_BIN valgrind REQUIRED)
 endif()
 
 macro(use_cxx17)
@@ -57,17 +62,29 @@ endif()
 
 include_directories(${XROOTD_INCLUDES} ${CURL_INCLUDE_DIRS} ${LIBCRYPTO_INCLUDE_DIRS})
 
-add_library(XrdS3 SHARED src/CurlUtil.cc src/S3File.cc src/S3Directory.cc src/S3AccessInfo.cc src/S3FileSystem.cc src/AWSv4-impl.cc src/S3Commands.cc src/HTTPCommands.cc src/TokenFile.cc src/stl_string_utils.cc src/shortfile.cc src/logging.cc)
-add_library(XrdHTTPServer SHARED src/CurlUtil.cc src/HTTPFile.cc src/HTTPFileSystem.cc src/HTTPCommands.cc src/TokenFile.cc src/stl_string_utils.cc src/shortfile.cc src/logging.cc)
+# On Linux, we hide all the symbols for the final libraries, exposing only what's needed for the XRootD
+# runtime loader.  So here we create the object library and will create a separate one for testing with
+# the symbols exposed.
+add_library(XrdS3Obj OBJECT src/CurlUtil.cc src/S3File.cc src/S3Directory.cc src/S3AccessInfo.cc src/S3FileSystem.cc src/AWSv4-impl.cc src/S3Commands.cc src/HTTPCommands.cc src/TokenFile.cc src/stl_string_utils.cc src/shortfile.cc src/logging.cc)
+target_include_directories(XrdS3Obj INTERFACE tinyxml2::tinyxml2)
+set_target_properties(XrdS3Obj PROPERTIES POSITION_INDEPENDENT_CODE ON)
+target_link_libraries(XrdS3Obj -ldl ${XROOTD_UTILS_LIB} ${XROOTD_SERVER_LIB} ${CURL_LIBRARIES} ${LIBCRYPTO_LIBRARIES} tinyxml2::tinyxml2 Threads::Threads)
 
-target_link_libraries(XrdS3 -ldl ${XROOTD_UTILS_LIB} ${XROOTD_SERVER_LIB} ${CURL_LIBRARIES} ${LIBCRYPTO_LIBRARIES} tinyxml2::tinyxml2 Threads::Threads)
-target_link_libraries(XrdHTTPServer -ldl ${XROOTD_UTILS_LIB} ${XROOTD_SERVER_LIB} ${CURL_LIBRARIES} ${LIBCRYPTO_LIBRARIES} Threads::Threads)
+add_library(XrdS3 MODULE "$<TARGET_OBJECTS:XrdS3Obj>")
+target_link_libraries(XrdS3 XrdS3Obj)
+
+add_library(XrdHTTPServerObj OBJECT src/CurlUtil.cc src/HTTPFile.cc src/HTTPFileSystem.cc src/HTTPCommands.cc src/TokenFile.cc src/stl_string_utils.cc src/shortfile.cc src/logging.cc)
+set_target_properties(XrdHTTPServerObj PROPERTIES POSITION_INDEPENDENT_CODE ON)
+target_link_libraries(XrdHTTPServerObj -ldl ${XROOTD_UTILS_LIB} ${XROOTD_SERVER_LIB} ${CURL_LIBRARIES} ${LIBCRYPTO_LIBRARIES} Threads::Threads)
+
+add_library(XrdHTTPServer MODULE "$<TARGET_OBJECTS:XrdHTTPServerObj>")
+target_link_libraries(XrdHTTPServer XrdHTTPServerObj)
 
 # The CMake documentation strongly advises against using these macros; instead, the pkg_check_modules
 # is supposed to fill out the full path to ${LIBCRYPTO_LIBRARIES}.  As of cmake 3.26.1, this does not
 # appear to be the case on Mac OS X.  Remove once no longer necessary!
-target_link_directories(XrdS3 PUBLIC ${LIBCRYPTO_LIBRARY_DIRS})
-target_link_directories(XrdHTTPServer PUBLIC ${LIBCRYPTO_LIBRARY_DIRS})
+target_link_directories(XrdS3Obj PUBLIC ${LIBCRYPTO_LIBRARY_DIRS})
+target_link_directories(XrdHTTPServerObj PUBLIC ${LIBCRYPTO_LIBRARY_DIRS})
 
 if(NOT APPLE)
   set_target_properties(XrdS3 PROPERTIES OUTPUT_NAME "XrdS3-${XROOTD_PLUGIN_VERSION}" SUFFIX ".so" LINK_FLAGS "-Wl,--version-script=${CMAKE_SOURCE_DIR}/configs/export-lib-symbols")
@@ -85,6 +102,11 @@ install(
 )
 
 if( XROOTD_PLUGINS_BUILD_UNITTESTS )
+  add_library(XrdS3Testing SHARED "$<TARGET_OBJECTS:XrdS3Obj>")
+  target_link_libraries(XrdS3Testing XrdS3Obj)
+  add_library(XrdHTTPServerTesting SHARED "$<TARGET_OBJECTS:XrdHTTPServerObj>")
+  target_link_libraries(XrdHTTPServerTesting XrdHTTPServerObj)
+
   if( NOT XROOTD_PLUGINS_EXTERNAL_GTEST )
     include(ExternalProject)
     ExternalProject_Add(gtest

--- a/src/CurlUtil.cc
+++ b/src/CurlUtil.cc
@@ -187,7 +187,7 @@ void CurlWorker::Run() {
 	// is waiting on it is undefined behavior.
 	auto queue_ref = m_queue;
 	auto &queue = *queue_ref.get();
-	m_logger.Log(LogMask::Debug, "CurlWorker::Run", "Started a curl worker");
+	m_logger.Log(LogMask::Debug, "Run", "Started a curl worker");
 
 	CURLM *multi_handle = curl_multi_init();
 	if (multi_handle == nullptr) {
@@ -213,7 +213,7 @@ void CurlWorker::Run() {
 			}
 			auto curl = queue.GetHandle();
 			if (curl == nullptr) {
-				m_logger.Log(LogMask::Debug, "CurlWorker",
+				m_logger.Log(LogMask::Debug, "Run",
 							 "Unable to allocate a curl handle");
 				op->Fail("E_NOMEM", "Unable to get allocate a curl handle");
 				continue;
@@ -223,7 +223,7 @@ void CurlWorker::Run() {
 					op->Fail(op->getErrorCode(), op->getErrorMessage());
 				}
 			} catch (...) {
-				m_logger.Log(LogMask::Debug, "CurlWorker",
+				m_logger.Log(LogMask::Debug, "Run",
 							 "Unable to setup the curl handle");
 				op->Fail("E_NOMEM",
 						 "Failed to setup the curl handle for the operation");
@@ -236,8 +236,7 @@ void CurlWorker::Run() {
 					std::stringstream ss;
 					ss << "Unable to add operation to the curl multi-handle: "
 					   << curl_multi_strerror(mres);
-					m_logger.Log(LogMask::Debug, "CurlWorker",
-								 ss.str().c_str());
+					m_logger.Log(LogMask::Debug, "Run", ss.str().c_str());
 				}
 				op->Fail("E_CURL_LIB",
 						 "Unable to add operation to the curl multi-handle");
@@ -253,7 +252,7 @@ void CurlWorker::Run() {
 			if (m_logger.getMsgMask() & LogMask::Debug) {
 				std::stringstream ss;
 				ss << "Curl worker thread " << getpid() << " is running "
-				   << running_handles << "operations";
+				   << running_handles << " operations";
 				m_logger.Log(LogMask::Debug, "CurlWorker", ss.str().c_str());
 			}
 			last_marker = now;
@@ -298,6 +297,8 @@ void CurlWorker::Run() {
 				}
 				auto &op = iter->second;
 				auto res = msg->data.result;
+				m_logger.Log(LogMask::Dump, "Run",
+							 "Processing result from curl");
 				op->ProcessCurlResult(iter->first, res);
 				op->ReleaseHandle(iter->first);
 				running_handles -= 1;

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -37,7 +37,7 @@ std::string XrdHTTPServer::LogMaskToString(int mask) {
 		has_entry = true;
 	}
 	if (mask & LogMask::Debug) {
-		ss << "debug";
+		ss << (has_entry ? ", " : "") << "debug";
 		has_entry = true;
 	}
 	if (mask & LogMask::Info) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,29 +1,10 @@
-add_executable( s3-gtest s3_tests.cc
-  ../src/AWSv4-impl.cc
-  ../src/CurlUtil.cc
-  ../src/logging.cc
-  ../src/S3AccessInfo.cc
-  ../src/S3Directory.cc
-  ../src/S3File.cc
-  ../src/S3FileSystem.cc
-  ../src/shortfile.cc
-  ../src/stl_string_utils.cc
-  ../src/TokenFile.cc
-  ../src/HTTPCommands.cc
-  ../src/S3Commands.cc
-)
+add_executable( s3-gtest s3_tests.cc )
 
-add_executable( http-gtest http_tests.cc
-  ../src/CurlUtil.cc
-  ../src/HTTPFile.cc
-  ../src/HTTPFileSystem.cc
-  ../src/HTTPCommands.cc
-  ../src/stl_string_utils.cc
-  ../src/TokenFile.cc
-  ../src/shortfile.cc
-  ../src/logging.cc
-)
+add_executable( s3-unit-test s3_unit_tests.cc )
 
+add_executable( http-gtest http_tests.cc )
+
+include(GoogleTest)
 
 if(XROOTD_PLUGINS_EXTERNAL_GTEST)
     set(LIBGTEST "gtest")
@@ -34,9 +15,16 @@ else()
     set(LIBGTEST "${CMAKE_BINARY_DIR}/external/gtest/src/gtest-build/lib/libgtest.a")
 endif()
 
-target_link_libraries(s3-gtest XrdS3 "${LIBGTEST}" pthread)
-target_link_libraries(http-gtest XrdHTTPServer "${LIBGTEST}" pthread)
+target_link_libraries(s3-gtest XrdS3Testing "${LIBGTEST}" pthread)
+target_link_libraries(s3-unit-test XrdS3Testing "${LIBGTEST}" pthread)
+target_link_libraries(http-gtest XrdHTTPServerTesting "${LIBGTEST}" pthread)
 
+gtest_add_tests(TARGET s3-unit-test TEST_LIST s3UnitTests)
+set_tests_properties(${s3UnitTests}
+  PROPERTIES
+    FIXTURES_REQUIRED S3::s3_basic
+    ENVIRONMENT "ENV_FILE=${CMAKE_BINARY_DIR}/tests/s3_basic/setup.sh"
+)
 
 add_test(
   NAME
@@ -51,6 +39,20 @@ add_test(
   COMMAND
     ${CMAKE_CURRENT_BINARY_DIR}/http-gtest "${CMAKE_BINARY_DIR}/tests/basic/setup.sh"
 )
+
+if (VALGRIND)
+  add_test(
+    NAME
+      valgrind-s3
+    COMMAND
+      ${VALGRIND_BIN} ${CMAKE_CURRENT_BINARY_DIR}/s3-unit-test -R FileSystemS3Fixture.UploadLargePartAligned
+  )
+
+  set_tests_properties(valgrind-s3
+    PROPERTIES
+      FIXTURES_REQUIRED S3::s3_basic
+  )
+endif()
 
 set_tests_properties(http-unit
   PROPERTIES

--- a/test/s3-setup.sh
+++ b/test/s3-setup.sh
@@ -150,6 +150,8 @@ export MINIO_ROOT_USER=minioadmin
 export MINIO_ROOT_PASSWORD=QXDEiQxQw8qY
 MINIO_USER=miniouser
 MINIO_PASSWORD=2Z303QCzRI7s
+printf "%s" "$MINIO_USER" > "$RUNDIR/access_key"
+printf "%s" "$MINIO_PASSWORD" > "$RUNDIR/secret_key"
 
 # Launch minio
 "$MINIO_BIN" --certs-dir "$MINIO_CERTSDIR" server --address "$(hostname):0" "$MINIO_DATADIR" 0<&- >"$BINARY_DIR/tests/$TEST_NAME/server.log" 2>&1 &
@@ -176,6 +178,8 @@ echo "Minio API server started on $MINIO_URL"
 cat > "$BINARY_DIR/tests/$TEST_NAME/setup.sh" <<EOF
 MINIO_URL=$MINIO_URL
 MINIO_PID=$MINIO_PID
+ACCESS_KEY_FILE=$RUNDIR/access_key
+SECRET_KEY_FILE=$RUNDIR/secret_key
 X509_CA_FILE=$MINIO_CERTSDIR/CAs/tlsca.pem
 EOF
 echo "Test environment written to $BINARY_DIR/tests/$TEST_NAME/setup.sh"
@@ -202,6 +206,7 @@ echo "Hello, World" > "$RUNDIR/hello_world.txt"
 ####
 
 export XROOTD_CONFIG="$XROOTD_CONFIGDIR/xrootd.cfg"
+BUCKET_NAME=test-bucket
 cat > "$XROOTD_CONFIG" <<EOF
 
 all.trace    all
@@ -236,7 +241,7 @@ s3.trace debug
 
 s3.begin
 s3.path_name /test
-s3.bucket_name test-bucket
+s3.bucket_name $BUCKET_NAME
 s3.service_url $MINIO_URL
 s3.service_name $(hostname)
 s3.url_style path
@@ -283,4 +288,5 @@ echo "xrootd started at $XROOTD_URL"
 cat >> "$BINARY_DIR/tests/$TEST_NAME/setup.sh" <<EOF
 XROOTD_PID=$XROOTD_PID
 XROOTD_URL=$XROOTD_URL
+BUCKET_NAME=$BUCKET_NAME
 EOF

--- a/test/s3_unit_tests.cc
+++ b/test/s3_unit_tests.cc
@@ -1,0 +1,421 @@
+/***************************************************************
+ *
+ * Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+//
+// The tests in this file are meant to work with the minio-based fixture,
+// meaning no internet connectivity is needed to run them.
+//
+
+#include "../src/S3Commands.hh"
+#include "../src/S3FileSystem.hh"
+#include "../src/shortfile.hh"
+
+#include <XrdOuc/XrdOucEnv.hh>
+#include <XrdSys/XrdSysError.hh>
+#include <XrdSys/XrdSysLogger.hh>
+#include <gtest/gtest.h>
+
+#include <fstream>
+#include <iostream>
+
+std::once_flag g_init_once;
+std::string g_ca_file;
+std::string g_minio_url;
+std::string g_bucket_name;
+std::string g_access_key_file;
+std::string g_secret_key_file;
+
+void parseEnvFile(const std::string &fname) {
+	std::ifstream fh(fname);
+	if (!fh.is_open()) {
+		std::cerr << "Failed to open env file: " << strerror(errno);
+		exit(1);
+	}
+	std::string line;
+	while (std::getline(fh, line)) {
+		auto idx = line.find("=");
+		if (idx == std::string::npos) {
+			continue;
+		}
+		auto key = line.substr(0, idx);
+		auto val = line.substr(idx + 1);
+		if (key == "X509_CA_FILE") {
+			g_ca_file = val;
+			setenv("X509_CERT_FILE", g_ca_file.c_str(), 1);
+		} else if (key == "MINIO_URL") {
+			g_minio_url = val;
+		} else if (key == "BUCKET_NAME") {
+			g_bucket_name = val;
+		} else if (key == "ACCESS_KEY_FILE") {
+			g_access_key_file = val;
+		} else if (key == "SECRET_KEY_FILE") {
+			g_secret_key_file = val;
+		}
+	}
+}
+
+class TestAmazonRequest : public AmazonRequest {
+  public:
+	XrdSysLogger log{};
+	XrdSysError err{&log, "TestS3CommandsLog"};
+
+	TestAmazonRequest(const std::string &url, const std::string &akf,
+					  const std::string &skf, const std::string &bucket,
+					  const std::string &object, const std::string &path,
+					  int sigVersion)
+		: AmazonRequest(url, akf, skf, bucket, object, path, sigVersion, err) {}
+
+	// For getting access to otherwise-protected members
+	std::string getHostUrl() const { return hostUrl; }
+};
+
+TEST(TestS3URLGeneration, Test1) {
+	const std::string serviceUrl = "https://s3-service.com:443";
+	const std::string b = "test-bucket";
+	const std::string o = "test-object";
+
+	// Test path-style URL generation
+	TestAmazonRequest pathReq{serviceUrl, "akf", "skf", b, o, "path", 4};
+	std::string generatedHostUrl = pathReq.getHostUrl();
+	ASSERT_EQ(generatedHostUrl,
+			  "https://s3-service.com:443/test-bucket/test-object");
+
+	// Test virtual-style URL generation
+	TestAmazonRequest virtReq{serviceUrl, "akf", "skf", b, o, "virtual", 4};
+	generatedHostUrl = virtReq.getHostUrl();
+	ASSERT_EQ(generatedHostUrl,
+			  "https://test-bucket.s3-service.com:443/test-object");
+
+	// Test path-style with empty bucket (which we use for exporting an entire
+	// endpoint)
+	TestAmazonRequest pathReqNoBucket{serviceUrl, "akf",  "skf", "",
+									  o,		  "path", 4};
+	generatedHostUrl = pathReqNoBucket.getHostUrl();
+	ASSERT_EQ(generatedHostUrl, "https://s3-service.com:443/test-object");
+}
+
+class FileSystemFixtureBase : public testing::Test {
+  protected:
+	FileSystemFixtureBase()
+		: m_log(new XrdSysLogger(2, 0)) // Log to stderr, no log rotation
+	{}
+
+	void SetUp() override {
+
+		setenv("XRDINSTANCE", "xrootd", 1);
+		char tmp_configfn[] = "/tmp/xrootd-s3-gtest.cfg.XXXXXX";
+		auto result = mkstemp(tmp_configfn);
+		ASSERT_NE(result, -1) << "Failed to create temp file ("
+							  << strerror(errno) << ", errno=" << errno << ")";
+		m_configfn = std::string(tmp_configfn);
+
+		auto contents = GetConfig();
+		ASSERT_FALSE(contents.empty());
+		ASSERT_TRUE(writeShortFile(m_configfn, contents, 0))
+			<< "Failed to write to temp file (" << strerror(errno)
+			<< ", errno=" << errno << ")";
+	}
+
+	void TearDown() override {
+		if (!m_configfn.empty()) {
+			auto rv = unlink(m_configfn.c_str());
+			ASSERT_EQ(rv, 0) << "Failed to delete temp file ("
+							 << strerror(errno) << ", errno=" << errno << ")";
+		}
+	}
+
+	virtual std::string GetConfig() = 0;
+
+	std::string m_configfn;
+	std::unique_ptr<XrdSysLogger> m_log;
+};
+
+class FileSystemS3VirtualBucket : public FileSystemFixtureBase {
+  protected:
+	virtual std::string GetConfig() override {
+		return R"(
+s3.begin
+s3.path_name        /test
+s3.bucket_name      genome-browser
+s3.service_name     s3.amazonaws.com
+s3.region           us-east-1
+s3.service_url      https://s3.us-east-1.amazonaws.com
+s3.url_style        virtual
+s3.end
+)";
+	}
+};
+
+class FileSystemS3VirtualNoBucket : public FileSystemFixtureBase {
+  protected:
+	virtual std::string GetConfig() override {
+		return R"(
+s3.begin
+s3.path_name        /test
+s3.service_name     s3.amazonaws.com
+s3.region           us-east-1
+s3.service_url      https://s3.us-east-1.amazonaws.com
+s3.url_style        virtual
+s3.end
+)";
+	}
+};
+
+class FileSystemS3PathBucket : public FileSystemFixtureBase {
+  protected:
+	virtual std::string GetConfig() override {
+		return R"(
+s3.begin
+s3.path_name        /test
+s3.service_name     s3.amazonaws.com
+s3.region           us-east-1
+s3.bucket_name      genome-browser
+s3.service_url      https://s3.us-east-1.amazonaws.com
+s3.url_style        path
+s3.end
+)";
+	}
+};
+
+class FileSystemS3PathNoBucket : public FileSystemFixtureBase {
+  protected:
+	virtual std::string GetConfig() override {
+		return R"(
+s3.begin
+s3.path_name        /test
+s3.service_name     s3.amazonaws.com
+s3.region           us-east-1
+s3.service_url      https://s3.us-east-1.amazonaws.com
+s3.url_style        path
+s3.end
+)";
+	}
+};
+
+// Regression test for when the service_url ends in a `/`
+class FileSystemS3PathBucketSlash : public FileSystemFixtureBase {
+  protected:
+	virtual std::string GetConfig() override {
+		return R"(
+s3.begin
+s3.path_name        /test
+s3.service_name     s3.amazonaws.com
+s3.region           us-east-1
+s3.bucket_name      genome-browser
+s3.service_url      https://s3.us-east-1.amazonaws.com/
+s3.url_style        path
+s3.end
+)";
+	}
+};
+
+TEST_F(FileSystemS3VirtualBucket, Create) {
+	EXPECT_NO_THROW(
+		{ S3FileSystem fs(m_log.get(), m_configfn.c_str(), nullptr); });
+}
+
+TEST_F(FileSystemS3VirtualNoBucket, Create) {
+	EXPECT_NO_THROW(
+		{ S3FileSystem fs(m_log.get(), m_configfn.c_str(), nullptr); });
+}
+
+TEST_F(FileSystemS3PathBucket, Create) {
+	EXPECT_NO_THROW(
+		{ S3FileSystem fs(m_log.get(), m_configfn.c_str(), nullptr); });
+}
+
+TEST_F(FileSystemS3PathNoBucket, Create) {
+	EXPECT_NO_THROW(
+		{ S3FileSystem fs(m_log.get(), m_configfn.c_str(), nullptr); });
+}
+
+TEST_F(FileSystemS3PathBucketSlash, Create) {
+	EXPECT_NO_THROW(
+		{ S3FileSystem fs(m_log.get(), m_configfn.c_str(), nullptr); });
+}
+
+// Tests where we query S3 test fixture
+class FileSystemS3Fixture : public FileSystemFixtureBase {
+	void SetUp() override {
+		std::call_once(g_init_once, [&] {
+			char *env_file = getenv("ENV_FILE");
+			ASSERT_NE(env_file, nullptr) << "$ENV_FILE environment variable "
+											"not set; required to run test";
+			parseEnvFile(env_file);
+
+			auto logger = new XrdSysLogger(2, 0);
+			auto log = new XrdSysError(logger, "curl_");
+			AmazonRequest::Init(*log);
+		});
+
+		FileSystemFixtureBase::SetUp();
+	}
+
+	virtual std::string GetConfig() override {
+		return R"(
+xrd.tlsca certfile )" +
+			   g_ca_file + R"(
+#s3.trace all dump
+s3.trace all
+s3.begin
+s3.path_name        /test
+s3.access_key_file  )" +
+			   g_access_key_file + R"(
+s3.secret_key_file  )" +
+			   g_secret_key_file + R"(
+s3.service_name     s3.example.com
+s3.region           us-east-1
+s3.bucket_name      )" +
+			   g_bucket_name + R"(
+s3.service_url      )" +
+			   g_minio_url + R"(
+s3.url_style        path
+s3.end
+	)";
+	}
+
+  public:
+	void WritePattern(const std::string &name, const off_t writeSize,
+					  const char chunkByte, const size_t chunkSize) {
+		XrdSysLogger log;
+		S3FileSystem fs(&log, m_configfn.c_str(), nullptr);
+
+		std::unique_ptr<XrdOssDF> fh(fs.newFile());
+		ASSERT_TRUE(fh);
+
+		XrdOucEnv env;
+		env.Put("oss.asize", std::to_string(writeSize).c_str());
+		auto rv = fh->Open(name.c_str(), O_CREAT | O_WRONLY, 0755, env);
+		ASSERT_EQ(rv, 0);
+
+		size_t sizeToWrite = (chunkSize >= writeSize) ? writeSize : chunkSize;
+		off_t curWriteSize = writeSize;
+		char curChunkByte = chunkByte;
+		off_t offset = 0;
+		while (sizeToWrite) {
+			std::string writeBuffer(sizeToWrite, curChunkByte);
+
+			std::cerr << "Writing bytes at offset: " << offset << std::endl;
+			rv = fh->Write(writeBuffer.data(), offset, sizeToWrite);
+			ASSERT_EQ(rv, sizeToWrite);
+
+			curWriteSize -= rv;
+			offset += rv;
+			sizeToWrite =
+				(chunkSize >= curWriteSize) ? curWriteSize : chunkSize;
+			curChunkByte += 1;
+		}
+
+		rv = fh->Close();
+		ASSERT_EQ(rv, 0);
+
+		VerifyContents(fs, name, writeSize, chunkByte, chunkSize);
+	}
+
+  private:
+	void VerifyContents(S3FileSystem &fs, const std::string &obj,
+						off_t expectedSize, char chunkByte, size_t chunkSize) {
+		std::unique_ptr<XrdOssDF> fh(fs.newFile());
+		ASSERT_TRUE(fh);
+
+		XrdOucEnv env;
+		auto rv = fh->Open(obj.c_str(), O_RDONLY, 0, env);
+		ASSERT_EQ(rv, 0);
+
+		size_t sizeToRead =
+			(chunkSize >= expectedSize) ? expectedSize : chunkSize;
+		char curChunkByte = chunkByte;
+		off_t offset = 0;
+		while (sizeToRead) {
+			std::string readBuffer(sizeToRead, curChunkByte - 1);
+			rv = fh->Read(readBuffer.data(), offset, sizeToRead);
+			ASSERT_EQ(rv, sizeToRead);
+			readBuffer.resize(rv);
+
+			std::string correctBuffer(sizeToRead, curChunkByte);
+			ASSERT_EQ(readBuffer, correctBuffer);
+
+			expectedSize -= rv;
+			offset += rv;
+			sizeToRead = (chunkSize >= expectedSize) ? expectedSize : chunkSize;
+			curChunkByte += 1;
+		}
+
+		rv = fh->Close();
+		ASSERT_EQ(rv, 0);
+	}
+};
+
+// Upload a single byte into S3
+TEST_F(FileSystemS3Fixture, UploadOneByte) {
+	WritePattern("/test/write_one.txt", 1, 'X', 32 * 1024);
+}
+
+// Upload across multiple calls, single part
+TEST_F(FileSystemS3Fixture, UploadMultipleCalls) {
+	WritePattern("/test/write_alphabet.txt", 26, 'a', 1);
+}
+
+// Upload a zero-byte object
+TEST_F(FileSystemS3Fixture, UploadZero) {
+	WritePattern("/test/write_zero.txt", 0, 'X', 32 * 1024);
+}
+
+// Upload larger - a few chunks.
+TEST_F(FileSystemS3Fixture, UploadMultipleChunks) {
+	WritePattern("/test/write_multi_chunks.txt", (10'000 / 1'024) * 1'024 + 42,
+				 'a', 1'024);
+}
+
+// Upload across multiple parts, not aligned to partition.
+TEST_F(FileSystemS3Fixture, UploadLarge) {
+	WritePattern("/test/write_large_1.txt",
+				 (100'000'000 / 1'310'720) * 1'310'720 + 42, 'a', 1'310'720);
+}
+
+// Upload a file into S3 that's the same size as the partition size
+TEST_F(FileSystemS3Fixture, UploadLargePart) {
+	WritePattern("/test/write_large_2.txt", 100'000'000, 'a', 131'072);
+}
+
+// Upload a small file where the partition size is aligned with the chunk size
+TEST_F(FileSystemS3Fixture, UploadSmallAligned) {
+	WritePattern("/test/write_large_3.txt", 1'000, 'a', 1'000);
+}
+
+// Upload a file into S3 that's the same size as the partition size, using
+// chunks that align with the partition size
+TEST_F(FileSystemS3Fixture, UploadLargePartAligned) {
+	WritePattern("/test/write_large_4.txt", 100'000'000, 'a', 1'000'000);
+}
+
+// Upload a file into S3 resulting in multiple partitions
+TEST_F(FileSystemS3Fixture, UploadMultiPartAligned) {
+	WritePattern("/test/write_large_5.txt", 100'000'000, 'a', 1'000'000);
+}
+
+// Upload a file into S3 resulting in multiple partitioned using not-aligned
+// chunks
+TEST_F(FileSystemS3Fixture, UploadMultiPartUnaligned) {
+	WritePattern("/test/write_large_1.txt", 100'000'000, 'a', 32'768);
+}
+
+int main(int argc, char **argv) {
+	::testing::InitGoogleTest(&argc, argv);
+	return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
This provides some minimal test cases for testing the S3 write code.

This does a small refactor of the CMake approach (mirroring what was done for xrdcl-pelican) to have an "object library", avoiding compiling the code once for the final output and again for the testing library.