### PR TITLE
Fix linking error on 32 bit architectures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,13 @@ else()
 	find_package(tinyxml2)
 endif()
 
+##
+# Flag is needed explicitly for 32-bit platforms but not currently exported by XRootD
+# as a reverse dependency.  Can be removed once this is merged and in all supported
+# releases:
+#
+# https://github.com/xrootd/xrootd/pull/2369
+#
 add_definitions( -D_FILE_OFFSET_BITS=64 )
 
 include_directories(${XROOTD_INCLUDES} ${CURL_INCLUDE_DIRS} ${LIBCRYPTO_INCLUDE_DIRS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,8 @@ else()
 	find_package(tinyxml2)
 endif()
 
+add_definitions( -D_FILE_OFFSET_BITS=64 )
+
 include_directories(${XROOTD_INCLUDES} ${CURL_INCLUDE_DIRS} ${LIBCRYPTO_INCLUDE_DIRS})
 
 add_library(XrdS3 SHARED src/CurlUtil.cc src/S3File.cc src/S3Directory.cc src/S3AccessInfo.cc src/S3FileSystem.cc src/AWSv4-impl.cc src/S3Commands.cc src/HTTPCommands.cc src/TokenFile.cc src/stl_string_utils.cc src/shortfile.cc src/logging.cc)


### PR DESCRIPTION
```
undefined reference to `XrdOssDF::pgRead(void*, long, unsigned int, unsigned int*, unsigned long long)'
undefined reference to `XrdOssDF::pgWrite(void*, long, unsigned int, unsigned int*, unsigned long long)'
```
Xrootd is compiled using -D_FILE_OFFSET_BITS=64. This means that the second parameter in pgRead/pgWrite, which is declared as off_t in xrootd's headers, is a long long on 32 bit architectures. Without -D_FILE_OFFSET_BITS=64 the off_t is a long and there is a mismatch which leads to a linking error.

Add -D_FILE_OFFSET_BITS=64 to the compiler definitions so that the compilation uses the same off_t definition as xrootd does during compilation.