### PR TITLE
Module for filtering exports

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,9 @@ endif()
 #
 add_definitions( -D_FILE_OFFSET_BITS=64 )
 
+######################
+##  libXrdOssS3     ##
+######################
 # On Linux, we hide all the symbols for the final libraries, exposing only what's needed for the XRootD
 # runtime loader.  So here we create the object library and will create a separate one for testing with
 # the symbols exposed.
@@ -80,6 +83,9 @@ target_link_libraries(XrdS3Obj ${XRootD_UTILS_LIBRARIES} ${XRootD_SERVER_LIBRARI
 add_library(XrdS3 MODULE "$<TARGET_OBJECTS:XrdS3Obj>")
 target_link_libraries(XrdS3 XrdS3Obj)
 
+######################
+##  libXrdOssHTTP   ##
+######################
 add_library(XrdHTTPServerObj OBJECT src/CurlUtil.cc src/HTTPFile.cc src/HTTPFileSystem.cc src/HTTPCommands.cc src/TokenFile.cc src/stl_string_utils.cc src/shortfile.cc src/logging.cc)
 set_target_properties(XrdHTTPServerObj PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_include_directories(XrdHTTPServerObj PRIVATE ${XRootD_INCLUDE_DIRS})
@@ -88,12 +94,26 @@ target_link_libraries(XrdHTTPServerObj ${XRootD_UTILS_LIBRARIES} ${XRootD_SERVER
 add_library(XrdHTTPServer MODULE "$<TARGET_OBJECTS:XrdHTTPServerObj>")
 target_link_libraries(XrdHTTPServer XrdHTTPServerObj)
 
-if(NOT APPLE)
-  set_target_properties(XrdS3 PROPERTIES OUTPUT_NAME "XrdS3-${XRootD_PLUGIN_VERSION}" SUFFIX ".so" LINK_FLAGS "-Wl,--version-script=${CMAKE_SOURCE_DIR}/configs/export-lib-symbols")
-  set_target_properties(XrdHTTPServer PROPERTIES OUTPUT_NAME "XrdHTTPServer-${XRootD_PLUGIN_VERSION}" SUFFIX ".so" LINK_FLAGS "-Wl,--version-script=${CMAKE_SOURCE_DIR}/configs/export-lib-symbols")
+######################
+## libXrdOssFilter  ##
+######################
+add_library( XrdOssFilterObj OBJECT src/Filter.cc src/logging.cc )
+set_target_properties( XrdOssFilterObj PROPERTIES POSITION_INDEPENDENT_CODE ON )
+target_include_directories( XrdOssFilterObj PRIVATE ${XRootD_INCLUDE_DIRS} )
+target_link_libraries( XrdOssFilterObj ${XRootD_UTILS_LIBRARIES} ${XRootD_SERVER_LIBRARIES} )
+
+add_library( XrdOssFilter MODULE "$<TARGET_OBJECTS:XrdOssFilterObj>" )
+target_link_libraries( XrdOssFilter XrdOssFilterObj )
+
+# Customize module's suffix and, on Linux, hide unnecessary symbols
+if( APPLE )
+  set_target_properties( XrdS3 PROPERTIES OUTPUT_NAME "XrdS3-${XRootD_PLUGIN_VERSION}" SUFFIX ".so" )
+  set_target_properties( XrdHTTPServer PROPERTIES OUTPUT_NAME "XrdHTTPServer-${XRootD_PLUGIN_VERSION}" SUFFIX ".so" )
+  set_target_properties( XrdOssFilter PROPERTIES OUTPUT_NAME "XrdOssFilter-${XRootD_PLUGIN_VERSION}" SUFFIX ".so" )
 else()
-  set_target_properties(XrdS3 PROPERTIES OUTPUT_NAME "XrdS3-${XRootD_PLUGIN_VERSION}" SUFFIX ".so")
-  set_target_properties(XrdHTTPServer PROPERTIES OUTPUT_NAME "XrdHTTPServer-${XRootD_PLUGIN_VERSION}" SUFFIX ".so")
+  set_target_properties( XrdS3 PROPERTIES OUTPUT_NAME "XrdS3-${XRootD_PLUGIN_VERSION}" SUFFIX ".so" LINK_FLAGS "-Wl,--version-script=${CMAKE_SOURCE_DIR}/configs/export-lib-symbols" )
+  set_target_properties( XrdHTTPServer PROPERTIES OUTPUT_NAME "XrdHTTPServer-${XRootD_PLUGIN_VERSION}" SUFFIX ".so" LINK_FLAGS "-Wl,--version-script=${CMAKE_SOURCE_DIR}/configs/export-lib-symbols" )
+  set_target_properties( XrdOssFilter PROPERTIES OUTPUT_NAME "XrdOssFilter-${XRootD_PLUGIN_VERSION}" SUFFIX ".so" LINK_FLAGS "-Wl,--version-script=${CMAKE_SOURCE_DIR}/configs/export-lib-symbols" )
 endif()
 
 SET(LIB_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/lib" CACHE PATH "Install path for libraries")
@@ -104,13 +124,20 @@ install(
 )
 
 if( BUILD_TESTING )
+  # Create shared libraries for testing from the existing objects
   add_library(XrdS3Testing SHARED "$<TARGET_OBJECTS:XrdS3Obj>")
   target_link_libraries(XrdS3Testing XrdS3Obj)
   target_include_directories(XrdS3Testing INTERFACE ${XRootD_INCLUDE_DIRS})
+
   add_library(XrdHTTPServerTesting SHARED "$<TARGET_OBJECTS:XrdHTTPServerObj>")
   target_link_libraries(XrdHTTPServerTesting XrdHTTPServerObj)
   target_include_directories(XrdHTTPServerTesting INTERFACE ${XRootD_INCLUDE_DIRS})
 
+  add_library( XrdOssFilterTesting SHARED "$<TARGET_OBJECTS:XrdOssFilterObj>" )
+  target_link_libraries( XrdOssFilterTesting XrdOssFilterObj )
+  target_include_directories( XrdOssFilterTesting INTERFACE ${XRootD_INCLUDE_DIRS} )
+
+  # Ensure that GTest is available
   if( NOT XROOTD_PLUGINS_EXTERNAL_GTEST )
     include( FetchContent )
     set( GTEST_URL "${CMAKE_CURRENT_SOURCE_DIR}/googletest-1.15.2.tar.gz" )
@@ -127,6 +154,7 @@ if( BUILD_TESTING )
   else()
     find_package(GTest REQUIRED)
   endif()
+
   enable_testing()
   add_subdirectory(test)
 endif()

--- a/src/Filter.cc
+++ b/src/Filter.cc
@@ -1,0 +1,617 @@
+/***************************************************************
+ *
+ * Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+#include "Filter.hh"
+#include "logging.hh"
+
+#include <fnmatch.h>
+#if defined(__GNU_SOURCE)
+#define FNMATCH_FLAGS (FNM_NOESCAPE | FNM_EXTMATCH)
+#else
+#define FNMATCH_FLAGS (FNM_NOESCAPE)
+#endif
+
+#include <XrdOuc/XrdOucGatherConf.hh>
+#include <XrdSec/XrdSecEntity.hh>
+#include <XrdSys/XrdSysError.hh>
+#include <XrdVersion.hh>
+
+#include <functional>
+
+using namespace XrdHTTPServer;
+
+FilterFileSystem::FilterFileSystem(XrdOss *oss, XrdSysLogger *log,
+								   const char *configName, XrdOucEnv *envP)
+	: XrdOssWrapper(*oss), m_oss(oss), m_log(log, "filter_") {
+	if (!Config(configName)) {
+		m_log.Emsg("Initialize", "Failed to configure the filter filesystem");
+		throw std::runtime_error("Failed to configure the filter filesystem");
+	}
+	m_log.Emsg("Initialize", "FilterFileSystem initialized");
+}
+
+FilterFileSystem::~FilterFileSystem() {}
+
+// Parse the provided file to configure the class
+//
+// We understand the following options:
+// - filter.trace [all|error|warning|info|debug|none]
+// - filter.glob [-a] [glob1] [glob2] ...
+// - filter.prefix [prefix1] [prefix2]
+// Each of the space-separated globs will be added to the list of permitted
+// paths for the filter.  If `-a` is specified, then path components beginning
+// with a `.` character will be matched.  The globs must be absolute paths.
+//
+// If a prefix is specified, everything underneath the prefix is permitted.
+//   filter.prefix /foo
+// is equivalent to
+//   filter.glob -a /foo/**
+bool FilterFileSystem::Config(const char *configfn) {
+	m_log.setMsgMask(LogMask::Error | LogMask::Warning);
+
+	XrdOucGatherConf filterConf("filter.trace filter.glob filter.prefix",
+								&m_log);
+	int result;
+	if ((result = filterConf.Gather(configfn, XrdOucGatherConf::trim_lines)) <
+		0) {
+		m_log.Emsg("Config", -result, "parsing config file", configfn);
+		return false;
+	}
+
+	char *val;
+	while (filterConf.GetLine()) {
+		val = filterConf.GetToken();
+		if (!strcmp(val, "trace")) {
+			m_log.setMsgMask(0);
+			if (!(val = filterConf.GetToken())) {
+				m_log.Emsg("Config",
+						   "filter.trace requires an argument.  Usage: "
+						   "filter.trace [all|error|warning|info|debug|none]");
+				return false;
+			}
+			do {
+				if (!strcmp(val, "all")) {
+					m_log.setMsgMask(m_log.getMsgMask() | LogMask::All);
+				} else if (!strcmp(val, "error")) {
+					m_log.setMsgMask(m_log.getMsgMask() | LogMask::Error);
+				} else if (!strcmp(val, "warning")) {
+					m_log.setMsgMask(m_log.getMsgMask() | LogMask::Error |
+									 LogMask::Warning);
+				} else if (!strcmp(val, "info")) {
+					m_log.setMsgMask(m_log.getMsgMask() | LogMask::Error |
+									 LogMask::Warning | LogMask::Info);
+				} else if (!strcmp(val, "debug")) {
+					m_log.setMsgMask(m_log.getMsgMask() | LogMask::Error |
+									 LogMask::Warning | LogMask::Info |
+									 LogMask::Debug);
+				} else if (!strcmp(val, "none")) {
+					m_log.setMsgMask(0);
+				}
+			} while ((val = filterConf.GetToken()));
+		} else if (!strcmp(val, "glob")) {
+			if (!(val = filterConf.GetToken())) {
+				m_log.Emsg("Config",
+						   "filter.glob requires an argument.  "
+						   "Usage: filter.glob [-a] [glob1] [glob2] ...");
+				return false;
+			}
+			auto all = false;
+			if (!strcmp(val, "-a")) {
+				all = true;
+				if (!(val = filterConf.GetToken())) {
+					m_log.Emsg("Config",
+							   "filter.glob requires an argument.  "
+							   "Usage: filter.glob [-a] [glob1] [glob2] ...");
+					return false;
+				}
+			}
+			do {
+				std::filesystem::path path(val);
+				if (!path.is_absolute()) {
+					m_log.Emsg("Config",
+							   "filter.glob requires an absolute path.  Usage: "
+							   "filter.glob [-a] [glob1] [glob2] ...");
+					return false;
+				}
+				m_globs.push_back({all, std::move(path)});
+			} while ((val = filterConf.GetToken()));
+		} else if (!strcmp(val, "prefix")) {
+			if (!(val = filterConf.GetToken())) {
+				m_log.Emsg("Config",
+						   "filter.prefix requires an argument.  "
+						   "Usage: filter.prefix [prefix1] [prefix2] ...");
+				return false;
+			}
+			do {
+				std::filesystem::path path(val);
+				if (!path.is_absolute()) {
+					m_log.Emsg(
+						"Config",
+						"filter.prefix requires an absolute path.  Usage: "
+						"filter.prefix [prefix1] [prefix2] ...");
+					return false;
+				}
+				m_globs.push_back({true, path / "**"});
+			} while ((val = filterConf.GetToken()));
+		} else {
+			m_log.Emsg("Config", "Unknown configuration directive", val);
+			return false;
+		}
+	}
+	if (m_globs.empty()) {
+		m_log.Emsg("Config", "No globs specified; will allow all paths");
+		return true;
+	}
+	for (const auto &glob : m_globs) {
+		m_log.Log(LogMask::Info, "Config", "Will permit glob",
+				  glob.m_glob.string().c_str(),
+				  glob.m_match_dotfile ? "all" : "");
+	}
+	return true;
+}
+
+int FilterFileSystem::Chmod(const char *path, mode_t mode, XrdOucEnv *env) {
+	return VerifyPath(path, true, &XrdOss::Chmod, path, mode, env);
+}
+
+int FilterFileSystem::Create(const char *tid, const char *path, mode_t mode,
+							 XrdOucEnv &env, int opts) {
+	return VerifyPath(path, false, &XrdOss::Create, tid, path, mode, env, opts);
+}
+
+int FilterFileSystem::Mkdir(const char *path, mode_t mode, int mkpath,
+							XrdOucEnv *envP) {
+	return VerifyPath(path, true, &XrdOss::Mkdir, path, mode, mkpath, envP);
+}
+
+int FilterFileSystem::Reloc(const char *tident, const char *path,
+							const char *cgName, const char *anchor) {
+	if (!path || !cgName) {
+		return -ENOENT;
+	}
+	bool partial;
+	if (!Glob(path, partial)) {
+		m_log.Log(LogMask::Debug, "Glob",
+				  "Failing relocation as source path matches no glob", path);
+		return -ENOENT;
+	}
+	if (!Glob(cgName, partial)) {
+		m_log.Log(LogMask::Debug, "Glob",
+				  "Failing relocation as destination path matches no glob",
+				  cgName);
+		return -ENOENT;
+	}
+	return wrapPI.Reloc(tident, path, cgName, anchor);
+}
+
+int FilterFileSystem::Remdir(const char *path, int Opts, XrdOucEnv *envP) {
+	return VerifyPath(path, true, &XrdOss::Remdir, path, Opts, envP);
+}
+
+int FilterFileSystem::Rename(const char *oPath, const char *nPath,
+							 XrdOucEnv *oEnvP, XrdOucEnv *nEnvP) {
+	if (!oPath || !nPath) {
+		return -ENOENT;
+	}
+	bool partial;
+	if (!Glob(oPath, partial)) {
+		m_log.Log(LogMask::Debug, "Glob",
+				  "Failing rename as source path matches no glob", oPath);
+		return -ENOENT;
+	}
+	if (!Glob(nPath, partial)) {
+		m_log.Log(LogMask::Debug, "Glob",
+				  "Failing rename as destination path matches no glob", nPath);
+		return -ENOENT;
+	}
+	return wrapPI.Rename(oPath, nPath, oEnvP, nEnvP);
+}
+
+int FilterFileSystem::Stat(const char *path, struct stat *buff, int opts,
+						   XrdOucEnv *env) {
+	return VerifyPath(path, true, &XrdOss::Stat, path, buff, opts, env);
+}
+
+int FilterFileSystem::StatFS(const char *path, char *buff, int &blen,
+							 XrdOucEnv *env) {
+	return VerifyPath(path, true, &XrdOss::StatFS, path, buff, blen, env);
+}
+
+int FilterFileSystem::StatLS(XrdOucEnv &env, const char *path, char *buff,
+							 int &blen) {
+	return VerifyPath(path, true, &XrdOss::StatLS, env, path, buff, blen);
+}
+
+int FilterFileSystem::StatPF(const char *path, struct stat *buff, int opts) {
+	return VerifyPath(
+		path, true,
+		static_cast<int (XrdOss::*)(const char *, struct stat *, int)>(
+			&XrdOss::StatPF),
+		path, buff, opts);
+}
+
+int FilterFileSystem::StatPF(const char *path, struct stat *buff) {
+	return VerifyPath(path, true,
+					  static_cast<int (XrdOss::*)(const char *, struct stat *)>(
+						  &XrdOss::StatPF),
+					  path, buff);
+}
+
+int FilterFileSystem::StatVS(XrdOssVSInfo *vsP, const char *sname, int updt) {
+	return VerifyPath(sname, true, &XrdOss::StatVS, vsP, sname, updt);
+}
+
+int FilterFileSystem::StatXA(const char *path, char *buff, int &blen,
+							 XrdOucEnv *env) {
+	return VerifyPath(path, true, &XrdOss::StatXA, path, buff, blen, env);
+}
+
+int FilterFileSystem::StatXP(const char *path, unsigned long long &attr,
+							 XrdOucEnv *env) {
+	return VerifyPath(path, true, &XrdOss::StatXP, path, attr, env);
+}
+
+int FilterFileSystem::Truncate(const char *path, unsigned long long fsize,
+							   XrdOucEnv *env) {
+	return VerifyPath(path, false, &XrdOss::Truncate, path, fsize, env);
+}
+
+int FilterFileSystem::Unlink(const char *path, int Opts, XrdOucEnv *env) {
+	return VerifyPath(path, false, &XrdOss::Unlink, path, Opts, env);
+}
+
+int FilterFileSystem::Lfn2Pfn(const char *Path, char *buff, int blen) {
+	return VerifyPath(Path, true,
+					  static_cast<int (XrdOss::*)(const char *, char *, int)>(
+						  &XrdOss::Lfn2Pfn),
+					  Path, buff, blen);
+}
+const char *FilterFileSystem::Lfn2Pfn(const char *Path, char *buff, int blen,
+									  int &rc) {
+	bool partial;
+	if (!Glob(Path, partial)) {
+		rc = -ENOENT;
+		return nullptr;
+	}
+	return wrapPI.Lfn2Pfn(Path, buff, blen, rc);
+}
+
+// Helper template for filesystem methods that need to verify the path passes
+// the filter.
+//
+// If `partial_ok` is set, then a partial match is permissible (typically, this
+// is done for stat- or directory-related methods to allow interacting with the
+// directory hierarchy).
+template <class Fn, class... Args>
+int FilterFileSystem::VerifyPath(std::string_view path, bool partial_ok,
+								 Fn &&fn, Args &&...args) {
+	bool partial;
+	if (!Glob(path, partial)) {
+		m_log.Log(LogMask::Debug, "Glob", "Path matches no glob", path.data());
+		return -ENOENT;
+	} else if (!partial_ok && partial) {
+		m_log.Log(LogMask::Debug, "Glob", "Path is a prefix of a glob",
+				  path.data());
+		return -EISDIR;
+	}
+	return std::invoke(fn, wrapPI, std::forward<Args>(args)...);
+}
+
+// Returns true if the path matches any of the globs, false otherwise.
+//
+bool FilterFileSystem::Glob(const char *path, bool &partial) {
+	if (!path) {
+		return false;
+	}
+	return Glob(std::filesystem::path(path), partial);
+}
+
+// Returns true if the path matches any of the globs, false otherwise.
+//
+bool FilterFileSystem::Glob(std::string_view path_view, bool &partial) {
+	return Glob(std::filesystem::path(path_view), partial);
+}
+
+// Returns true if the path matches any of the globs, false otherwise.
+//
+// If the path is a prefix of any of the globs, `partial` will be set to true
+// on return. For example, if the glob is /foo/*/*.txt and the path is
+// /foo/bar, then partial will be set to true.
+bool FilterFileSystem::Glob(const std::filesystem::path &path, bool &partial) {
+	if (m_globs.empty()) {
+		partial = false;
+		return true;
+	}
+	if (!path.is_absolute()) {
+		return false;
+	}
+	for (const auto &glob : m_globs) {
+		if (GlobOne(path, glob, partial)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+// Core logic for evaluating a path against a single glob match pattern.
+//
+// Returns `true` if the path matches the glob - or if the path is the prefix
+// of a potential path that matches the glob.  In the latter case, `partial`
+// will be set to `true` on return.
+bool FilterFileSystem::GlobOne(const std::filesystem::path &path,
+							   const glob &glob, bool &partial) {
+	auto path_iter = path.begin();
+	auto match = true;
+	for (auto glob_iter = glob.m_glob.begin(); glob_iter != glob.m_glob.end();
+		 ++glob_iter, ++path_iter) {
+		// The path has fewer components than the provided glob.
+		if (path_iter == path.end()) {
+			// The globstar can match against zero components, meaning if the
+			// full glob ends in globstar (and that's the next component), then
+			// this is actually a full match.
+			if (*glob_iter == "**" && ++glob_iter == glob.m_glob.end()) {
+				partial = false;
+			} else {
+				partial = true;
+			}
+			return true;
+		}
+		// Logic for the "globstar" operator.  The globstar evaluates to
+		// match zero-or-more paths.
+		if (*glob_iter == "**") {
+			auto cur_glob_component = glob_iter;
+			// If the globstar is at the end of the glob, then we match
+			// any subsequent part of the path.
+			if (++cur_glob_component == glob.m_glob.end()) {
+				return true;
+			} else {
+				// To evaluate the globstar, we compare the remainder of the
+				// glob against the remainder of the path.  Since the globstar
+				// can consume any number of path components, we start with the
+				// shortest possible path and recursively call `GlobOne` with
+				// increasingly longer ones.
+				//
+				// So, if the glob is /foo/**/2*/bar and the path is
+				// /foo/1/22/bar, then the new glob after the globstar will be
+				// `/2/bar`.  The for-loop below will start with comparing the
+				// glob `/2*/bar` against the path `/bar`, then grow the path
+				// and compare against `/22/bar` (then matching).
+				auto new_glob = std::filesystem::path("/");
+				for (auto iter = cur_glob_component; iter != glob.m_glob.end();
+					 iter++) {
+					new_glob /= *iter;
+				}
+				// If there is a "dot file" in the path and we are not matching
+				// dotfiles, then we must have a full match as the globstar
+				// operator doesn't match such path components by default.
+				bool has_dotfile = false;
+				if (!glob.m_match_dotfile) {
+					// Detect the presence of a dotfile
+					for (auto iter = path_iter; iter != path.end(); iter++) {
+						const auto &path_component = iter->string();
+						if (!path_component.empty() &&
+							path_component[0] == '.') {
+							has_dotfile = true;
+							break;
+						}
+					}
+				}
+				std::string cur_glob = *cur_glob_component;
+				auto potential_match = true;
+				for (auto back_iter = --path.end();; back_iter--) {
+					auto subpath = std::filesystem::path("/");
+					auto path_prefix_has_dotfile = false;
+					if (has_dotfile) {
+						for (auto iter = path_iter; iter != back_iter; iter++) {
+							const auto &path_component = iter->string();
+							if (!path_component.empty() &&
+								path_component[0] == '.') {
+								path_prefix_has_dotfile = true;
+								break;
+							}
+						}
+					}
+					for (auto iter = back_iter; iter != path.end(); iter++) {
+						subpath /= *iter;
+					}
+					bool subpartial;
+					if (GlobOne(subpath, {glob.m_match_dotfile, new_glob},
+								subpartial)) {
+						if (!subpartial && !path_prefix_has_dotfile) {
+							return true;
+						} else if (path_prefix_has_dotfile) {
+							potential_match = false;
+						}
+					} else if (has_dotfile) {
+						potential_match = false;
+					}
+					// By placing the break condition here, instead of in the
+					// for construct, we test the case where back_iter ==
+					// path_iter.
+					if (back_iter == path_iter) {
+						break;
+					}
+				}
+				// The globstar can always 'consume' all the path components,
+				// resuming in a partial match beyond it. That is,
+				//   Path: /foo/bar/baz, Glob: /foo/**/idx.txt
+				// Is going to be a partial match because the path could be the
+				// prefix for
+				//   /foo/bar/baz/idx.txt
+				if (potential_match) {
+					partial = true;
+					return true;
+				}
+				return false;
+			}
+		}
+		// Rely on the libc fnmatch function to implement the glob logic for a
+		// single component.
+		int rc;
+		if (FNM_NOMATCH ==
+			(rc = fnmatch(glob_iter->c_str(), path_iter->c_str(),
+						  FNMATCH_FLAGS |
+							  (glob.m_match_dotfile ? 0 : FNM_PERIOD)))) {
+			match = false;
+			break;
+		} else if (rc) {
+			m_log.Log(LogMask::Warning, "Glob", "Error in fnmatch for glob",
+					  glob_iter->c_str(), std::to_string(rc).c_str());
+		}
+	}
+	// If the path has more components than the glob -- and there were no
+	// globstar operators found -- then we cannot have a match.  Otherwise, we
+	// consumed all the glob and path components and we have a full match.
+	if (path_iter != path.end()) {
+		match = false;
+	}
+	if (match) {
+		partial = false;
+		return true;
+	}
+	return false;
+}
+
+XrdOssDF *FilterFileSystem::newFile(char const *user) {
+	std::unique_ptr<XrdOssDF> wrapped(m_oss->newFile(user));
+	return new FilterFile(std::move(wrapped), m_log, *this);
+}
+
+XrdOssDF *FilterFileSystem::newDir(char const *user) {
+	std::unique_ptr<XrdOssDF> wrapped(m_oss->newDir(user));
+	return new FilterDir(std::move(wrapped), m_log, *this);
+}
+
+FilterDir::~FilterDir() {}
+
+int FilterDir::Opendir(const char *path, XrdOucEnv &env) {
+	if (!path) {
+		return -ENOENT;
+	}
+	bool partial;
+	if (!m_oss.Glob(path, partial)) {
+		m_log.Log(LogMask::Debug, "Opendir",
+				  "Ignoring directory as it passes no glob", path);
+		return -ENOENT;
+	}
+	m_prefix = path;
+	return wrapDF.Opendir(path, env);
+}
+
+int FilterDir::Readdir(char *buff, int blen) {
+	m_stat_avail = false;
+	while (true) {
+		auto rc = wrapDF.Readdir(buff, blen);
+		if (rc) {
+			return rc;
+		}
+		if (*buff == '\0') {
+			return 0;
+		} else if (!strcmp(buff, ".") || !strcmp(buff, "..")) {
+			// Always permit special current and parent directory links.
+			return 0;
+		}
+		auto path = m_prefix / std::string_view(buff, strnlen(buff, blen));
+		bool partial;
+		if (m_oss.Glob(path, partial)) {
+			if (partial) {
+				struct stat buff;
+				auto rc = StatRet(&buff);
+				if (rc) {
+					return rc;
+				}
+				if (buff.st_mode & S_IFDIR) {
+					return 0;
+				}
+				m_stat_avail = false;
+				if (m_log.getMsgMask() & LogMask::Debug) {
+					m_log.Log(LogMask::Debug, "Readdir",
+							  "Ignoring file in directory as it is a prefix "
+							  "for a glob",
+							  path.string().c_str());
+				}
+			} else {
+				return 0;
+			}
+		} else if (m_log.getMsgMask() & LogMask::Debug) {
+			m_log.Log(LogMask::Debug, "Readdir",
+					  "Ignoring directory component as it passes no glob",
+					  path.string().c_str());
+		}
+	}
+}
+
+// Returns the struct stat corresponding to the current
+// directory entry name.
+//
+// If `Readdir` required a stat of the path to determine
+// if its visible, the cached copy may be served here.
+int FilterDir::StatRet(struct stat *buff) {
+	if (m_stat_avail) {
+		memcpy(buff, &m_stat, sizeof(m_stat));
+		return 0;
+	}
+	auto rc = wrapDF.StatRet(&m_stat);
+	if (!rc) {
+		m_stat_avail = true;
+		memcpy(buff, &m_stat, sizeof(m_stat));
+	}
+	return rc;
+}
+
+int FilterDir::Close(long long *retsz) {
+	m_prefix.clear();
+	return wrapDF.Close(retsz);
+}
+
+FilterFile::~FilterFile() {}
+
+int FilterFile::Open(const char *path, int Oflag, mode_t Mode, XrdOucEnv &env) {
+	bool partial;
+	if (!m_oss.Glob(path, partial)) {
+		m_log.Log(LogMask::Debug, "Glob",
+				  "Failing file open as path matches no glob", path);
+		return -ENOENT;
+	} else if (partial) {
+		m_log.Log(LogMask::Debug, "Glob",
+				  "Failing file open as path is a prefix of a glob", path);
+		return -EISDIR;
+	}
+	return wrapDF.Open(path, Oflag, Mode, env);
+}
+
+extern "C" {
+
+XrdVERSIONINFO(XrdOssAddStorageSystem2, Filter);
+
+XrdOss *XrdOssAddStorageSystem2(XrdOss *curr_oss, XrdSysLogger *logger,
+								const char *config_fn, const char *parms,
+								XrdOucEnv *envP) {
+
+	XrdSysError log(logger, "filter_");
+	try {
+		return new FilterFileSystem(curr_oss, logger, config_fn, envP);
+	} catch (std::runtime_error &re) {
+		log.Emsg("Initialize",
+				 "Encountered a runtime failure when initializing the "
+				 "filter filesystem:",
+				 re.what());
+		return nullptr;
+	}
+}
+}

--- a/src/Filter.hh
+++ b/src/Filter.hh
@@ -93,6 +93,8 @@ class FilterFileSystem final : public XrdOssWrapper {
 	bool GlobOne(const std::filesystem::path &path, const glob &glob,
 				 bool &partial);
 
+	std::pair<bool, std::string> SanitizePrefix(const std::filesystem::path &);
+
   private:
 	template <class Fn, class... Args>
 	int VerifyPath(std::string_view path, bool partial_ok, Fn &&fn,

--- a/src/Filter.hh
+++ b/src/Filter.hh
@@ -1,0 +1,144 @@
+/***************************************************************
+ *
+ * Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+#include <XrdOss/XrdOssWrapper.hh>
+#include <XrdSys/XrdSysError.hh>
+#include <XrdVersion.hh>
+
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <vector>
+
+class XrdOucEnv;
+class XrdSecEntity;
+class XrdSysError;
+
+//
+// A filesystem wrapper which only permits accessing specific paths.
+//
+// For example, if the filter is "/foo/*.txt", then the underlying
+// path /foo/test.txt will be accessible but the paths /bar.txt and
+// /foo/test.csv will result in an ENOENT.
+//
+class FilterFileSystem final : public XrdOssWrapper {
+  public:
+	struct glob {
+		bool m_match_dotfile{false};
+		std::filesystem::path m_glob;
+	};
+
+	FilterFileSystem(XrdOss *oss, XrdSysLogger *log, const char *configName,
+					 XrdOucEnv *envP);
+
+	virtual ~FilterFileSystem();
+
+	bool Config(const char *configfn);
+
+	XrdOssDF *newDir(const char *user = 0) override;
+	XrdOssDF *newFile(const char *user = 0) override;
+
+	virtual int Chmod(const char *path, mode_t mode,
+					  XrdOucEnv *env = 0) override;
+	virtual int Create(const char *tid, const char *path, mode_t mode,
+					   XrdOucEnv &env, int opts = 0) override;
+	virtual int Mkdir(const char *path, mode_t mode, int mkpath = 0,
+					  XrdOucEnv *envP = 0) override;
+	virtual int Reloc(const char *tident, const char *path, const char *cgName,
+					  const char *anchor = 0) override;
+	virtual int Remdir(const char *path, int Opts = 0,
+					   XrdOucEnv *envP = 0) override;
+	virtual int Rename(const char *oPath, const char *nPath,
+					   XrdOucEnv *oEnvP = 0, XrdOucEnv *nEnvP = 0) override;
+	virtual int Stat(const char *path, struct stat *buff, int opts = 0,
+					 XrdOucEnv *env = 0) override;
+	virtual int StatFS(const char *path, char *buff, int &blen,
+					   XrdOucEnv *env = 0) override;
+	virtual int StatLS(XrdOucEnv &env, const char *path, char *buff,
+					   int &blen) override;
+	virtual int StatPF(const char *path, struct stat *buff, int opts) override;
+	virtual int StatPF(const char *path, struct stat *buff) override;
+	virtual int StatVS(XrdOssVSInfo *vsP, const char *sname = 0,
+					   int updt = 0) override;
+	virtual int StatXA(const char *path, char *buff, int &blen,
+					   XrdOucEnv *env = 0) override;
+	virtual int StatXP(const char *path, unsigned long long &attr,
+					   XrdOucEnv *env = 0) override;
+	virtual int Truncate(const char *path, unsigned long long fsize,
+						 XrdOucEnv *env = 0) override;
+	virtual int Unlink(const char *path, int Opts = 0,
+					   XrdOucEnv *env = 0) override;
+	virtual int Lfn2Pfn(const char *Path, char *buff, int blen) override;
+	virtual const char *Lfn2Pfn(const char *Path, char *buff, int blen,
+								int &rc) override;
+
+	bool Glob(const char *path, bool &partial);
+	bool Glob(std::string_view path, bool &partial);
+	bool Glob(const std::filesystem::path &path, bool &partial);
+	bool GlobOne(const std::filesystem::path &path, const glob &glob,
+				 bool &partial);
+
+  private:
+	template <class Fn, class... Args>
+	int VerifyPath(std::string_view path, bool partial_ok, Fn &&fn,
+				   Args &&...args);
+
+	std::vector<glob> m_globs;
+	std::unique_ptr<XrdOss> m_oss;
+	XrdSysError m_log;
+};
+
+class FilterFile final : public XrdOssWrapDF {
+  public:
+	FilterFile(std::unique_ptr<XrdOssDF> wrapDF, XrdSysError &log,
+			   FilterFileSystem &oss)
+		: XrdOssWrapDF(*wrapDF), m_wrapped(std::move(wrapDF)), m_log(log),
+		  m_oss(oss) {}
+
+	virtual ~FilterFile();
+
+	int Open(const char *path, int Oflag, mode_t Mode, XrdOucEnv &env) override;
+
+  private:
+	std::unique_ptr<XrdOssDF> m_wrapped;
+	XrdSysError &m_log;
+	FilterFileSystem &m_oss;
+};
+
+class FilterDir final : public XrdOssWrapDF {
+  public:
+	FilterDir(std::unique_ptr<XrdOssDF> wrapDF, XrdSysError &log,
+			  FilterFileSystem &oss)
+		: XrdOssWrapDF(*wrapDF), m_wrapped(std::move(wrapDF)), m_log(log),
+		  m_oss(oss) {}
+
+	virtual ~FilterDir();
+
+	virtual int Opendir(const char *path, XrdOucEnv &env) override;
+	virtual int Readdir(char *buff, int blen) override;
+	virtual int StatRet(struct stat *buff) override;
+	virtual int Close(long long *retsz = 0) override;
+
+  private:
+	bool m_stat_avail{false};
+	struct stat m_stat;
+	std::unique_ptr<XrdOssDF> m_wrapped;
+	XrdSysError &m_log;
+	FilterFileSystem &m_oss;
+	std::filesystem::path m_prefix;
+};

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,10 +4,14 @@ include(GoogleTest)
 add_executable( s3-gtest s3_tests.cc )
 add_executable( s3-unit-test s3_unit_tests.cc )
 add_executable( http-gtest http_tests.cc )
+add_executable( filter-gtest filter_tests.cc ../src/shortfile.cc )
 
 target_link_libraries(s3-gtest XrdS3Testing GTest::gtest_main Threads::Threads)
 target_link_libraries(s3-unit-test XrdS3Testing GTest::gtest_main Threads::Threads)
 target_link_libraries(http-gtest XrdHTTPServerTesting GTest::gtest_main Threads::Threads)
+target_link_libraries(filter-gtest XrdOssFilterTesting GTest::gtest_main Threads::Threads)
+
+gtest_add_tests(TARGET filter-gtest)
 
 gtest_add_tests(TARGET s3-unit-test TEST_LIST s3UnitTests)
 set_tests_properties(${s3UnitTests}

--- a/test/filter_tests.cc
+++ b/test/filter_tests.cc
@@ -1,0 +1,459 @@
+/***************************************************************
+ *
+ * Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+#include "../src/Filter.hh"
+#include "s3_tests_common.hh"
+
+#include <XrdOss/XrdOss.hh>
+#include <XrdOuc/XrdOucEnv.hh>
+
+#include <string>
+
+class SimpleDir final : public XrdOssDF {
+  public:
+	virtual int Opendir(const char *path, XrdOucEnv &env) {
+		if (!strncmp(path, "/prefix", 7)) {
+			m_subdir = !strcmp(path, "/prefix3");
+			return 0;
+		}
+		return -ENOENT;
+	}
+	virtual int Readdir(char *buff, int blen) {
+		if (m_idx >= 3) {
+			if (m_subdir && m_idx == 3 && blen >= 8) {
+				memcpy(buff, "idx.txt", 8);
+				m_idx++;
+				return 0;
+			}
+			buff[0] = '\0';
+			return 0;
+		}
+		auto result = (m_subdir ? "subdir" : "idx") + std::to_string(m_idx++) +
+					  (m_subdir ? "" : ".txt");
+		if (result.size() + 1 < static_cast<unsigned>(blen)) {
+			memcpy(buff, result.c_str(), result.size());
+			buff[result.size()] = '\0';
+		} else {
+			return -ENOMEM;
+		}
+		return 0;
+	}
+	virtual int StatRet(struct stat *buff) {
+		if (!buff)
+			return 0;
+		memset(buff, '\0', sizeof(struct stat));
+		buff->st_mode = 0750 | ((m_subdir && m_idx <= 3) ? S_IFDIR : S_IFREG);
+		buff->st_size = m_idx;
+		return 0;
+	}
+	virtual int Close(long long *retsz = 0) {
+		m_idx = 0;
+		return 0;
+	}
+
+  private:
+	bool m_subdir{false};
+	unsigned m_idx{0};
+};
+
+class SimpleFile final : public XrdOssDF {
+  public:
+	virtual int Fchmod(mode_t mode) { return 0; }
+	virtual void Flush() {}
+	virtual int Fstat(struct stat *buf) {
+		if (!buf)
+			return 0;
+		memset(buf, '\0', sizeof(struct stat));
+		buf->st_mode = 0640 | S_IFREG;
+		return 0;
+	}
+	virtual int Fsync() { return 0; }
+	virtual int Fsync(XrdSfsAio *aiop) { return 0; }
+	virtual int Ftruncate(unsigned long long flen) { return 0; }
+	virtual int Open(const char *path, int Oflag, mode_t Mode, XrdOucEnv &env) {
+		return 0;
+	}
+	virtual ssize_t pgRead(void *buffer, off_t offset, size_t rdlen,
+						   uint32_t *csvec, uint64_t opts) {
+		return 0;
+	}
+	virtual int pgRead(XrdSfsAio *aioparm, uint64_t opts) { return 0; }
+	virtual ssize_t pgWrite(void *buffer, off_t offset, size_t wrlen,
+							uint32_t *csvec, uint64_t opts) {
+		return 0;
+	}
+	virtual int pgWrite(XrdSfsAio *aioparm, uint64_t opts) { return 0; }
+	virtual ssize_t Read(off_t offset, size_t size) { return 0; }
+	virtual ssize_t Read(void *buffer, off_t offset, size_t size) { return 0; }
+	virtual int Read(XrdSfsAio *aiop) {
+		(void)aiop;
+		return 0;
+	}
+	virtual ssize_t ReadRaw(void *buffer, off_t offset, size_t size) {
+		return 0;
+	}
+	virtual ssize_t ReadV(XrdOucIOVec *readV, int rdvcnt) { return 0; }
+	virtual ssize_t Write(const void *buffer, off_t offset, size_t size) {
+		return 0;
+	}
+	virtual int Write(XrdSfsAio *aiop) {
+		(void)aiop;
+		return 0;
+	}
+	virtual ssize_t WriteV(XrdOucIOVec *writeV, int wrvcnt) { return 0; }
+	virtual int Close(long long *retsz = 0) { return 0; }
+	virtual int Fctl(int cmd, int alen, const char *args, char **resp = 0) {
+		return 0;
+	}
+};
+
+class SimpleFilesystem final : public XrdOss {
+  public:
+	virtual XrdOssDF *newDir(char const *user) { return new SimpleDir; }
+	virtual XrdOssDF *newFile(char const *user) { return new SimpleFile; }
+	virtual int Chmod(const char *path, mode_t mode, XrdOucEnv *envP = 0) {
+		return 0;
+	}
+	virtual int Create(const char *tid, const char *path, mode_t mode,
+					   XrdOucEnv &env, int opts = 0) {
+		return 0;
+	}
+	virtual int Init(XrdSysLogger *lp, const char *cfn) { return 0; }
+	virtual int Mkdir(const char *path, mode_t mode, int mkpath = 0,
+					  XrdOucEnv *envP = 0) {
+		return 0;
+	}
+	virtual int Remdir(const char *path, int Opts = 0, XrdOucEnv *envP = 0) {
+		return 0;
+	}
+	virtual int Rename(const char *oPath, const char *nPath,
+					   XrdOucEnv *oEnvP = 0, XrdOucEnv *nEnvP = 0) {
+		return 0;
+	}
+	virtual int Stat(const char *path, struct stat *buff, int opts = 0,
+					 XrdOucEnv *envP = 0);
+	virtual int Truncate(const char *path, unsigned long long fsize,
+						 XrdOucEnv *envP = 0) {
+		return 0;
+	}
+	virtual int Unlink(const char *path, int Opts = 0, XrdOucEnv *envP = 0) {
+		return 0;
+	}
+	virtual ~SimpleFilesystem() {}
+};
+
+int SimpleFilesystem::Stat(const char *path, struct stat *buff, int opts,
+						   XrdOucEnv *envP) {
+	if (!strcmp(path, "/prefix1") || !strcmp(path, "/prefix2") ||
+		!strcmp(path, "/prefix3") || !strcmp(path, "/prefix4") ||
+		!strcmp(path, "/prefix3/subdir1") ||
+		!strcmp(path, "/prefix3/subdir2") ||
+		!strcmp(path, "/prefix3/subdir3") ||
+		!strcmp(path, "/prefix3/subdir4")) {
+		if (!buff)
+			return 0;
+		memset(buff, '\0', sizeof(struct stat));
+		buff->st_mode = 0750 | S_IFDIR;
+		return 0;
+	}
+	if (!strcmp(path, "/prefix1/idx0.txt") ||
+		!strcmp(path, "/prefix2/idx1.txt") ||
+		!strcmp(path, "/prefix2/idx2.txt") ||
+		!strcmp(path, "/prefix2/idx3.txt") ||
+		!strcmp(path, "/prefix2/idx4.txt") ||
+		!strcmp(path, "/prefix3/subdir1/1.txt") ||
+		!strcmp(path, "/prefix3/subdir1/2.txt") ||
+		!strcmp(path, "/prefix3/subdir1/3.txt") ||
+		!strcmp(path, "/prefix3/subdir1/4.txt") ||
+		!strcmp(path, "/prefix3/subdir2/1.txt") ||
+		!strcmp(path, "/prefix3/subdir2/2.txt") ||
+		!strcmp(path, "/prefix3/subdir2/3.txt") ||
+		!strcmp(path, "/prefix3/subdir1/4.txt") ||
+		!strcmp(path, "/prefix3/subdir3/1.txt") ||
+		!strcmp(path, "/prefix3/subdir3/2.txt") ||
+		!strcmp(path, "/prefix3/subdir3/3.txt") ||
+		!strcmp(path, "/prefix3/subdir3/4.txt") ||
+		!strcmp(path, "/prefix3/subdir4/1.txt") ||
+		!strcmp(path, "/prefix4/subdir2/idx0.txt") ||
+		!strcmp(path, "/prefix5/idx.txt")) {
+		if (!buff)
+			return 0;
+		memset(buff, '\0', sizeof(struct stat));
+		buff->st_mode = 0750 | S_IFREG;
+		return 0;
+	}
+	return -ENOENT;
+}
+
+class FileSystemGlob : public FileSystemFixtureBase {
+  protected:
+	virtual std::string GetConfig() override {
+		return R"(
+filter.glob /prefix1 /prefix2/*.txt
+filter.glob /prefix3/*/*.txt
+filter.prefix /prefix5
+filter.trace all
+)";
+	}
+};
+
+TEST_F(FileSystemGlob, GlobFilter) {
+	SimpleFilesystem sfs;
+	XrdSysLogger log;
+	FilterFileSystem fs(new SimpleFilesystem, &log, m_configfn.c_str(),
+						nullptr);
+	XrdOucEnv env;
+
+	struct stat buf;
+	ASSERT_EQ(sfs.Stat("/prefix1", &buf), 0);
+	ASSERT_EQ(fs.Stat("/prefix1", &buf), 0);
+	ASSERT_EQ(sfs.Stat("/prefix1/idx0.txt", &buf), 0);
+	ASSERT_EQ(fs.Stat("/prefix1/idx0.txt", &buf), -ENOENT);
+	ASSERT_EQ(fs.Stat("/prefix5/idx0.txt", &buf), -ENOENT);
+	ASSERT_EQ(fs.Stat("/prefix5/idx.txt", &buf), 0);
+
+	std::unique_ptr<XrdOssDF> sfsdir(sfs.newDir(""));
+	ASSERT_NE(nullptr, sfsdir);
+	ASSERT_EQ(sfsdir->Opendir("/prefix1", env), 0);
+	char buff[256];
+	ASSERT_EQ(sfsdir->Readdir(buff, 256), 0);
+	ASSERT_STREQ(buff, "idx0.txt");
+	ASSERT_EQ(sfsdir->Readdir(buff, 256), 0);
+	ASSERT_STREQ(buff, "idx1.txt");
+	ASSERT_EQ(sfsdir->Readdir(buff, 256), 0);
+	ASSERT_STREQ(buff, "idx2.txt");
+	ASSERT_EQ(sfsdir->Readdir(buff, 256), 0);
+	ASSERT_STREQ(buff, "");
+	ASSERT_EQ(sfsdir->Close(), 0);
+
+	std::unique_ptr<XrdOssDF> fsdir(fs.newDir());
+	ASSERT_NE(nullptr, fsdir);
+	ASSERT_EQ(fsdir->Opendir("/prefix1", env), 0);
+	ASSERT_EQ(fsdir->Readdir(buff, 256), 0);
+	ASSERT_STREQ(buff, "");
+	ASSERT_EQ(fsdir->Close(), 0);
+
+	ASSERT_EQ(fsdir->Opendir("/prefix2", env), 0);
+	ASSERT_EQ(fsdir->Readdir(buff, 256), 0);
+	ASSERT_STREQ(buff, "idx0.txt");
+	ASSERT_EQ(fsdir->Readdir(buff, 256), 0);
+	ASSERT_STREQ(buff, "idx1.txt");
+	ASSERT_EQ(fsdir->Readdir(buff, 256), 0);
+	ASSERT_STREQ(buff, "idx2.txt");
+	ASSERT_EQ(fsdir->Readdir(buff, 256), 0);
+	ASSERT_STREQ(buff, "");
+	ASSERT_EQ(fsdir->Close(), 0);
+
+	sfsdir.reset(sfs.newDir(""));
+	ASSERT_NE(sfsdir.get(), nullptr);
+	ASSERT_EQ(sfsdir->Opendir("/prefix3", env), 0);
+	ASSERT_EQ(sfsdir->Readdir(buff, 256), 0);
+	ASSERT_STREQ(buff, "subdir0");
+	ASSERT_EQ(sfsdir->Readdir(buff, 256), 0);
+	ASSERT_STREQ(buff, "subdir1");
+	ASSERT_EQ(sfsdir->Readdir(buff, 256), 0);
+	ASSERT_STREQ(buff, "subdir2");
+	ASSERT_EQ(sfsdir->Readdir(buff, 256), 0);
+	ASSERT_STREQ(buff, "idx.txt");
+	ASSERT_EQ(sfsdir->Readdir(buff, 256), 0);
+	ASSERT_STREQ(buff, "");
+	ASSERT_EQ(sfsdir->Close(), 0);
+
+	ASSERT_EQ(fsdir->Opendir("/prefix3", env), 0);
+	ASSERT_EQ(fsdir->Readdir(buff, 256), 0);
+	ASSERT_STREQ(buff, "subdir0");
+	ASSERT_EQ(fsdir->Readdir(buff, 256), 0);
+	ASSERT_STREQ(buff, "subdir1");
+	ASSERT_EQ(fsdir->Readdir(buff, 256), 0);
+	ASSERT_STREQ(buff, "subdir2");
+	ASSERT_EQ(fsdir->Readdir(buff, 256), 0);
+	ASSERT_STREQ(buff, "");
+	ASSERT_EQ(fsdir->Close(), 0);
+	ASSERT_EQ(fsdir->Opendir("/prefix3/subdir0", env), 0);
+	ASSERT_EQ(fsdir->Readdir(buff, 256), 0);
+	ASSERT_STREQ(buff, "idx0.txt");
+	ASSERT_EQ(fsdir->Readdir(buff, 256), 0);
+	ASSERT_STREQ(buff, "idx1.txt");
+	ASSERT_EQ(fsdir->Readdir(buff, 256), 0);
+	ASSERT_STREQ(buff, "idx2.txt");
+	ASSERT_EQ(fsdir->Readdir(buff, 256), 0);
+	ASSERT_STREQ(buff, "");
+	ASSERT_EQ(fsdir->Close(), 0);
+
+	std::unique_ptr<XrdOssDF> fsfile(fs.newFile());
+	ASSERT_NE(nullptr, fsfile);
+	ASSERT_EQ(fsfile->Open("/prefix1/idx0.txt", 0, 0, env), -ENOENT);
+	std::unique_ptr<XrdOssDF> sfsfile(sfs.newFile(""));
+	ASSERT_NE(nullptr, sfsfile);
+	ASSERT_EQ(sfsfile->Open("/prefix1/idx0.txt", 0, 0, env), 0);
+	fsfile.reset(fs.newFile());
+	ASSERT_NE(nullptr, fsfile);
+	ASSERT_EQ(fsfile->Open("/prefix2/idx0.txt", 0, 0, env), 0);
+	fsfile.reset(fs.newFile());
+	ASSERT_NE(nullptr, fsfile);
+	ASSERT_EQ(fsfile->Open("/prefix3/subdir2/idx0.txt", 0, 0, env), 0);
+	fsfile.reset(fs.newFile());
+	ASSERT_NE(nullptr, fsfile);
+	ASSERT_EQ(fsfile->Open("/prefix4/subdir2/idx0.txt", 0, 0, env), -ENOENT);
+	sfsfile.reset(sfs.newFile(""));
+	ASSERT_NE(nullptr, sfsfile);
+	ASSERT_EQ(sfsfile->Open("/prefix4/subdir2/idx0.txt", 0, 0, env), 0);
+}
+
+TEST_F(FileSystemGlob, GlobNormal) {
+	XrdSysLogger log;
+	FilterFileSystem fs(new SimpleFilesystem, &log, m_configfn.c_str(),
+						nullptr);
+	XrdOucEnv env;
+	bool partial;
+	XrdSysError dst(&log, "FileSystemGlob");
+
+	dst.Emsg("Glob", "Testing /");
+	ASSERT_TRUE(fs.GlobOne("/", {false, "/*"}, partial));
+	ASSERT_TRUE(partial);
+	ASSERT_TRUE(fs.GlobOne("/", {false, "/"}, partial));
+	ASSERT_FALSE(partial);
+
+	dst.Emsg("Glob", "Testing /foo");
+	ASSERT_TRUE(fs.GlobOne("/foo", {false, "/*"}, partial));
+	ASSERT_FALSE(partial);
+	dst.Emsg("Globstar", "Testing /bar");
+	ASSERT_FALSE(fs.GlobOne("/foo", {false, "/bar"}, partial));
+	ASSERT_FALSE(partial);
+
+	dst.Emsg("Glob", "Testing /foo/bar/idx.txt");
+	ASSERT_FALSE(fs.GlobOne("/foo/bar/idx.txt", {false, "/foo/*"}, partial));
+	ASSERT_FALSE(partial);
+	ASSERT_TRUE(
+		fs.GlobOne("/foo/bar/idx.txt", {false, "/foo/bar/idx.txt"}, partial));
+	ASSERT_FALSE(partial);
+	ASSERT_TRUE(fs.GlobOne("/foo/bar/idx.txt", {false, "/foo/bar/idx.txt/baz"},
+						   partial));
+	ASSERT_TRUE(partial);
+	ASSERT_TRUE(
+		fs.GlobOne("/foo/bar/idx.txt", {false, "/foo/*/idx.txt"}, partial));
+	ASSERT_FALSE(partial);
+	ASSERT_TRUE(
+		fs.GlobOne("/foo/bar/idx.txt", {false, "/foo/*/*.txt"}, partial));
+	ASSERT_FALSE(partial);
+	ASSERT_TRUE(
+		fs.GlobOne("/foo/bar/idx.txt", {false, "/foo/bar/*.txt"}, partial));
+	ASSERT_FALSE(partial);
+	ASSERT_TRUE(
+		fs.GlobOne("/foo/bar/idx.txt", {false, "/foo/bar/idx.*"}, partial));
+	ASSERT_FALSE(partial);
+	ASSERT_FALSE(
+		fs.GlobOne("/foo/bar/idx.txt", {false, "/foo/bar/t.*"}, partial));
+	ASSERT_FALSE(partial);
+
+	dst.Emsg("Glob", "Testing /foo/.bar/idx.txt");
+	ASSERT_TRUE(
+		fs.GlobOne("/foo/.bar/idx.txt", {true, "/foo/*/idx.txt"}, partial));
+	ASSERT_FALSE(partial);
+	ASSERT_FALSE(
+		fs.GlobOne("/foo/.bar/idx.txt", {false, "/foo/*/idx.txt"}, partial));
+	dst.Emsg("Glob", "Testing /.bar");
+	ASSERT_TRUE(fs.GlobOne("/.bar", {true, "/*"}, partial));
+	ASSERT_FALSE(partial);
+	ASSERT_FALSE(fs.GlobOne("/.bar", {false, "/*"}, partial));
+}
+
+TEST_F(FileSystemGlob, Globstar) {
+	XrdSysLogger log;
+	FilterFileSystem fs(new SimpleFilesystem, &log, m_configfn.c_str(),
+						nullptr);
+	XrdOucEnv env;
+	bool partial;
+	XrdSysError dst(&log, "FileSystemGlob");
+	dst.Emsg("Globstar", "Testing /some/path");
+	ASSERT_TRUE(fs.GlobOne("/some/path", {false, "/some/**"}, partial));
+	ASSERT_FALSE(partial);
+	dst.Emsg("Globstar", "Testing /");
+	ASSERT_TRUE(fs.GlobOne("/", {false, "/**"}, partial));
+	ASSERT_FALSE(partial);
+	dst.Emsg("Globstar", "Testing /some");
+	ASSERT_TRUE(fs.GlobOne("/some", {false, "/**"}, partial));
+	ASSERT_FALSE(partial);
+	dst.Emsg("Globstar", "Testing /some");
+	ASSERT_TRUE(fs.GlobOne("/some", {false, "/some/**"}, partial));
+	ASSERT_FALSE(partial);
+	dst.Emsg("Globstar", "Testing /some/path/subdir/foo.txt");
+	ASSERT_TRUE(
+		fs.GlobOne("/some/path/subdir/foo.txt", {false, "/some/**"}, partial));
+	ASSERT_FALSE(partial);
+	dst.Emsg("Globstar", "Testing /foo/bar/idx.txt");
+	ASSERT_TRUE(
+		fs.GlobOne("/foo/bar/idx.txt", {false, "/foo/**/idx.txt"}, partial));
+	ASSERT_FALSE(partial);
+	dst.Emsg("Globstar", "Testing /foo/bar/baz/idx.txt");
+	ASSERT_TRUE(fs.GlobOne("/foo/bar/baz/idx.txt", {false, "/foo/**/idx.txt"},
+						   partial));
+	ASSERT_FALSE(partial);
+	dst.Emsg("Globstar", "Testing /foo/idx.txt");
+	ASSERT_TRUE(
+		fs.GlobOne("/foo/idx.txt", {false, "/foo/**/idx.txt"}, partial));
+	ASSERT_FALSE(partial);
+	dst.Emsg("Globstar", "Testing /foo/bar/idx.txt");
+	ASSERT_TRUE(fs.GlobOne("/foo/bar/idx.txt", {false, "/foo/**/bar/idx.txt"},
+						   partial));
+	ASSERT_FALSE(partial);
+	dst.Emsg("Globstar", "Testing /foo/bar/bar/idx.txt");
+	ASSERT_TRUE(fs.GlobOne("/foo/bar/bar/idx.txt",
+						   {false, "/foo/**/bar/idx.txt"}, partial));
+	ASSERT_FALSE(partial);
+	dst.Emsg("Globstar", "Testing /foo/bar/bar");
+	ASSERT_TRUE(
+		fs.GlobOne("/foo/bar/bar", {false, "/foo/**/bar/idx.txt"}, partial));
+	ASSERT_TRUE(partial);
+	dst.Emsg("Globstar", "Testing /foo/bar/idx.txt");
+	ASSERT_TRUE(
+		fs.GlobOne("/foo/bar/idx.txt", {false, "/foo/**/false"}, partial));
+	ASSERT_TRUE(partial);
+
+	// Test that "dot files" are not matched by the globstar operator,
+	// matching the bash implementation.
+	dst.Emsg("Globstar", "Testing /foo/.bar/idx.txt");
+	partial = false;
+	ASSERT_FALSE(
+		fs.GlobOne("/foo/.bar/idx.txt", {false, "/foo/**/idx.txt"}, partial));
+	ASSERT_FALSE(partial);
+	ASSERT_TRUE(
+		fs.GlobOne("/foo/.bar/idx.txt", {true, "/foo/**/idx.txt"}, partial));
+	ASSERT_FALSE(partial);
+	ASSERT_TRUE(
+		fs.GlobOne("/foo/.bar/idx.txt", {true, "/foo/**/bar.txt"}, partial));
+	ASSERT_TRUE(partial);
+	partial = false;
+	dst.Emsg("Globstar", "Testing negative match with dotfile");
+	ASSERT_FALSE(
+		fs.GlobOne("/foo/.bar/idx.txt", {false, "/foo/**/bar.txt"}, partial));
+	ASSERT_FALSE(partial);
+	ASSERT_TRUE(
+		fs.GlobOne("/foo/.bar/idx.txt", {true, "/foo/**/bar.txt"}, partial));
+	ASSERT_TRUE(partial);
+	dst.Emsg("Globstra", "Testing /foo/1/.bar/idx.txt");
+	ASSERT_FALSE(
+		fs.GlobOne("/foo/1/.bar/idx.txt", {false, "/foo/**/idx.txt"}, partial));
+	ASSERT_TRUE(fs.GlobOne("/foo/1/.bar/idx.txt",
+						   {false, "/foo/**/.bar/idx.txt"}, partial));
+	ASSERT_TRUE(fs.GlobOne("/foo/1/.bar/idx.txt",
+						   {false, "/foo/**/1/.bar/idx.txt"}, partial));
+	dst.Emsg("Globstra", "Testing /foo/.1/.bar/idx.txt");
+	ASSERT_FALSE(fs.GlobOne("/foo/.1/.bar/idx.txt",
+							{false, "/foo/**/.bar/idx.txt"}, partial));
+}

--- a/test/s3-setup.sh
+++ b/test/s3-setup.sh
@@ -200,6 +200,7 @@ fi
 
 echo "Hello, World" > "$RUNDIR/hello_world.txt"
 "$MC_BIN" --insecure --config-dir "$MINIO_CLIENTDIR" cp "$RUNDIR/hello_world.txt" userminio/test-bucket/hello_world.txt
+"$MC_BIN" --insecure --config-dir "$MINIO_CLIENTDIR" cp "$RUNDIR/hello_world.txt" userminio/test-bucket/hello_world2.txt
 
 ####
 #    Starting XRootD config with S3 backend
@@ -236,11 +237,29 @@ xrd.tls $MINIO_CERTSDIR/public.crt $MINIO_CERTSDIR/private.key
 
 oss.local_root /
 ofs.osslib $BINARY_DIR/libXrdS3.so
+ofs.osslib ++ $BINARY_DIR/libXrdOssFilter.so
 
 s3.trace debug
 
 s3.begin
 s3.path_name /test
+s3.bucket_name $BUCKET_NAME
+s3.service_url $MINIO_URL
+s3.service_name $(hostname)
+s3.url_style path
+s3.region us-east-1
+s3.access_key_file $XROOTD_CONFIGDIR/access_key
+s3.secret_key_file $XROOTD_CONFIGDIR/secret_key
+s3.end
+
+#
+# Integration test for the filter module.  Export the
+# same bucket again as /test2 but filter out some contents
+#
+filter.prefix /test
+filter.glob /test2/hello_world.*
+s3.begin
+s3.path_name /test2
 s3.bucket_name $BUCKET_NAME
 s3.service_url $MINIO_URL
 s3.service_name $(hostname)

--- a/test/s3-test.sh
+++ b/test/s3-test.sh
@@ -44,3 +44,19 @@ if [ "$HTTP_CODE" -ne 404 ]; then
   echo "Expected HTTP code is 404; actual was $HTTP_CODE"
   exit 1
 fi
+
+echo "Running $TEST_NAME - filtered prefix"
+
+HTTP_CODE=$(curl --cacert $X509_CA_FILE --output /dev/null -v --write-out '%{http_code}' "$XROOTD_URL/test2/hello_world.txt" 2>> "$BINARY_DIR/tests/$TEST_NAME/filter.log")
+
+if [ "$HTTP_CODE" -ne 200 ]; then
+  echo "Expected HTTP code is 200; actual was $HTTP_CODE"
+  exit 1
+fi
+
+HTTP_CODE=$(curl --cacert $X509_CA_FILE --output /dev/null -v --write-out '%{http_code}' "$XROOTD_URL/test2/hello_world2.txt" 2>> "$BINARY_DIR/tests/$TEST_NAME/filter.log")
+
+if [ "$HTTP_CODE" -ne 404 ]; then
+  echo "Expected HTTP code is 404; actual was $HTTP_CODE"
+  exit 1
+fi


### PR DESCRIPTION
This PR (note: it's built on top of #79 and hence it contains those commits -- ignore them for review purposes or wait until that PR is merged) adds a new module, `libXrdOssFilter`, for managing what objects are exported via XRootD.

`libXrdOssFilter` can be stacked on top of the HTTP or S3 OSS plugin and provides reasonably fine-grained control over what data is accessible.  The administrator can limit things to specific prefixes or only objects matching a certain glob (e.g., `/ncar/dataset*/**` or `/foo/*.png`).  It supports the "globstar" operator, allowing multiple path hierarchies to be matched (e.g., `/pelican/**/*.go` will export all `*.go` files underneath `/pelican`).  The integration test contains a valid XRootD configuration file demonstrating this.

Includes reasonable unit test and a simple end-to-end integration test built on top of the S3 integration test.