### PR TITLE
Add small stress test based on go-wrk

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,9 @@ jobs:
     - uses: actions/checkout@v3
       with:
         submodules: recursive
+    - uses: actions/setup-go@v5
+      with:
+        go-version: '1.23.5'
     - name: install deps
       run: |
         sudo curl -L https://xrootd.web.cern.ch/repo/RPM-GPG-KEY.txt -o /etc/apt/trusted.gpg.d/xrootd.asc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,18 @@ if( BUILD_TESTING )
   target_link_libraries(XrdHTTPServerTesting XrdHTTPServerObj)
   target_include_directories(XrdHTTPServerTesting INTERFACE ${XRootD_INCLUDE_DIRS})
 
+  find_program(GoWrk go-wrk HINTS "$ENV{HOME}/go/bin")
+  if( NOT GoWrk )
+    # Try installing the go-wrk variable to generate a reasonable stress test
+    execute_process( COMMAND go install github.com/bbockelm/go-wrk@92dbe19
+      RESULT_VARIABLE go_install_result )
+    if( go_install_result EQUAL 0 )
+      find_program(GoWrk go-wrk HINTS "$ENV{HOME}/go/bin")
+    else()
+      message(ERROR "Failed to install the go-wrk binary" )
+    endif()
+  endif()
+
   if( NOT XROOTD_PLUGINS_EXTERNAL_GTEST )
     include( FetchContent )
     set( GTEST_URL "${CMAKE_CURRENT_SOURCE_DIR}/googletest-1.15.2.tar.gz" )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -58,7 +58,7 @@ add_test(NAME HTTP::basic::setup
 set_tests_properties(HTTP::basic::setup
   PROPERTIES
     FIXTURES_SETUP HTTP::basic
-    ENVIRONMENT "BINARY_DIR=${CMAKE_BINARY_DIR};SOURCE_DIR=${CMAKE_SOURCE_DIR}"
+    ENVIRONMENT "BINARY_DIR=${CMAKE_BINARY_DIR};SOURCE_DIR=${CMAKE_SOURCE_DIR};XROOTD_BINDIR=${XRootD_DATA_DIR}/../bin"
 )
 
 add_test(NAME HTTP::basic::teardown
@@ -92,7 +92,7 @@ add_test(NAME S3::s3_basic::setup
 set_tests_properties(S3::s3_basic::setup
   PROPERTIES
     FIXTURES_SETUP S3::s3_basic
-    ENVIRONMENT "BINARY_DIR=${CMAKE_BINARY_DIR};SOURCE_DIR=${CMAKE_SOURCE_DIR}"
+    ENVIRONMENT "BINARY_DIR=${CMAKE_BINARY_DIR};SOURCE_DIR=${CMAKE_SOURCE_DIR};XROOTD_BINDIR=${XRootD_DATA_DIR}/../bin"
 )
 
 add_test(NAME S3::s3_basic::teardown
@@ -124,5 +124,19 @@ set_tests_properties(S3::s3_basic::stress_test
   PROPERTIES
     FIXTURES_REQUIRED S3::s3_basic
     ENVIRONMENT "BINARY_DIR=${CMAKE_BINARY_DIR}"
+    ATTACHED_FILES_ON_FAIL "${S3_BASIC_TEST_LOGS}"
+)
+
+#######################################
+# Stress-test using the go-wrk binary #
+#######################################
+
+add_test( NAME S3::s3_basic::gowrk_test
+  COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/s3-gowrk-test.sh" s3_basic )
+
+set_tests_properties( S3::s3_basic::gowrk_test
+  PROPERTIES
+    FIXTURES_REQUIRED S3::s3_basic
+    ENVIRONMENT "BINARY_DIR=${CMAKE_BINARY_DIR};WRK_BIN=${GoWrk}"
     ATTACHED_FILES_ON_FAIL "${S3_BASIC_TEST_LOGS}"
 )

--- a/test/s3-gowrk-test.sh
+++ b/test/s3-gowrk-test.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+TEST_NAME=$1
+
+if [ -z "$BINARY_DIR" ]; then
+  echo "\$BINARY_DIR environment variable is not set; cannot run test"
+  exit 1
+fi
+if [ ! -d "$BINARY_DIR" ]; then
+  echo "$BINARY_DIR is not a directory; cannot run test"
+  exit 1
+fi
+
+echo "Running $TEST_NAME - go-wrk based stress test"
+
+echo > "$BINARY_DIR/tests/$TEST_NAME/client.log"
+
+if [ ! -f "$BINARY_DIR/tests/$TEST_NAME/setup.sh" ]; then
+  echo "Test environment file $BINARY_DIR/tests/$TEST_NAME/setup.sh does not exist - cannot run test"
+  exit 1
+fi
+. "$BINARY_DIR/tests/$TEST_NAME/setup.sh"
+
+"$WRK_BIN" -c 200 -d 10 -no-vr -T 10000 -f "$PLAYBACK_FILE"

--- a/test/xrdhttp-setup.sh
+++ b/test/xrdhttp-setup.sh
@@ -21,8 +21,7 @@ fi
 
 echo "Setting up HTTP server for $TEST_NAME test"
 
-XROOTD_BIN="$(command -v xrootd)"
-
+XROOTD_BIN="$XROOTD_BINDIR/xrootd"
 if [ -z "XROOTD_BIN" ]; then
   echo "xrootd binary not found; cannot run unit test"
   exit 1
@@ -183,6 +182,10 @@ while [ -z "$XROOTD_URL" ]; do
   sleep 1
   XROOTD_URL=$(grep "Xrd_ProtLoad: enabling port" "$BINARY_DIR/tests/$TEST_NAME/server.log" | grep 'for protocol XrdHttp' | awk '{print $7}')
   IDX=$(($IDX+1))
+  if ! kill -0 "$XROOTD_PID" 2>/dev/null; then
+    echo "xrootd process (PID $XROOTD_PID) failed to start" >&2
+    exit 1
+  fi
   if [ $IDX -gt 1 ]; then
     echo "Waiting for xrootd to start ($IDX seconds so far) ..."
   fi


### PR DESCRIPTION
Higher concurrency -- hopefully more likely to trigger threading errors.

(This is the same test as #85 but I'm hoping, without the small patches, it'll trigger a crash as well)