### PR TITLE
Fix RPM-based builds

### DIFF
--- a/rpm/xrootd-s3-http.spec
+++ b/rpm/xrootd-s3-http.spec
@@ -1,5 +1,5 @@
 Name:		xrootd-s3-http
-Version:        0.2.1
+Version:        0.2.0
 Release:        1%{?dist}
 Summary:        S3/HTTP filesystem plugins for xrootd
 
@@ -44,7 +44,7 @@ Requires: xrootd-server <  1:%{xrootd_next_major}.0.0-1
 %license LICENSE
 
 %changelog
-* Sat Feb 1 2025 Brian Bockelman <bbockelman@morgridge.org> - 0.2.1-1
+* Sat Feb 1 2025 Brian Bockelman <bbockelman@morgridge.org> - 0.2.0-1
 - Bump to upstream version 0.2.1.
 
 * Tue Nov 28 2023 Justin Hiemstra <jhiemstra@wisc.edu> - 0.0.2-1

--- a/rpm/xrootd-s3-http.spec
+++ b/rpm/xrootd-s3-http.spec
@@ -32,7 +32,7 @@ Requires: xrootd-server <  1:%{xrootd_next_major}.0.0-1
 %setup -q
 
 %build
-%cmake .
+%cmake . -DCMAKE_BUILD_TYPE=RelWithDebInfo
 %cmake_build
 
 %install

--- a/rpm/xrootd-s3-http.spec
+++ b/rpm/xrootd-s3-http.spec
@@ -1,26 +1,23 @@
-Name: xrootd-s3-http
-Version: 0.0.2
-Release: 1%{?dist}
-Summary: S3/HTTP filesystem plugins for xrootd
+Name:		xrootd-s3-http
+Version:        0.2.1
+Release:        1%{?dist}
+Summary:        S3/HTTP filesystem plugins for xrootd
 
-Group: System Environment/Daemons
-License: BSD
-# Generated from:
-# git archive v%{version} --prefix=xrootd-s3-http-%{version}/ | gzip -7 > ~/rpmbuild/SOURCES/xrootd-s3-http-%{version}.tar.gz
-URL: https://github.com/pelicanplatform/xrootd-s3-http
-Source0: %{name}-%{version}.tar.gz
+License:        Apache-2.0
+URL:            https://github.com/PelicanPlatform/%{name}
+Source0:        %{url}/archive/refs/tags/v%{version}/%{name}-%{version}.tar.gz
 
 %define xrootd_current_major 5
-%define xrootd_current_minor 5
+%define xrootd_current_minor 7
 %define xrootd_next_major 6
 
-BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
+BuildRequires: cmake3
+BuildRequires: gcc-c++
+BuildRequires: make
 BuildRequires: xrootd-server-libs >= 1:%{xrootd_current_major}
 BuildRequires: xrootd-server-libs <  1:%{xrootd_next_major}
 BuildRequires: xrootd-server-devel >= 1:%{xrootd_current_major}
 BuildRequires: xrootd-server-devel <  1:%{xrootd_next_major}
-BuildRequires: cmake3
-BuildRequires: gcc-c++
 BuildRequires: libcurl-devel
 BuildRequires: openssl-devel
 
@@ -34,19 +31,22 @@ Requires: xrootd-server <  1:%{xrootd_next_major}.0.0-1
 %setup -q
 
 %build
-%cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo .
-make VERBOSE=1 %{?_smp_mflags}
+%cmake .
+%cmake_build
 
 %install
-rm -rf $RPM_BUILD_ROOT
-make install DESTDIR=$RPM_BUILD_ROOT
+%cmake_install
 
 %files
-%defattr(-,root,root,-)
-%{_libdir}/libXrdS3*.so
-%{_libdir}/libXrdHTTPServer*.so
+%{_libdir}/libXrdHTTPServer-5.so
+%{_libdir}/libXrdS3-5.so
+%doc README.md
+%license LICENSE
 
 %changelog
+* Sat Feb 1 2025 Brian Bockelman <bbockelman@morgridge.org> - 0.2.1-1
+- Bump to upstream version 0.2.1.
+
 * Tue Nov 28 2023 Justin Hiemstra <jhiemstra@wisc.edu> - 0.0.2-1
 - Add HTTPServer plugin
 

--- a/rpm/xrootd-s3-http.spec
+++ b/rpm/xrootd-s3-http.spec
@@ -32,7 +32,7 @@ Requires: xrootd-server <  1:%{xrootd_next_major}.0.0-1
 %setup -q
 
 %build
-%cmake . -DCMAKE_BUILD_TYPE=RelWithDebInfo
+%cmake . -DCMAKE_BUILD_TYPE=RelWithDebInfo -DXROOTD_EXTERNAL_TINYXML2=ON
 %cmake_build
 
 %install

--- a/rpm/xrootd-s3-http.spec
+++ b/rpm/xrootd-s3-http.spec
@@ -33,7 +33,7 @@ Requires: xrootd-server <  1:%{xrootd_next_major}.0.0-1
 
 %build
 %cmake . -DCMAKE_BUILD_TYPE=RelWithDebInfo -DXROOTD_EXTERNAL_TINYXML2=ON
-%cmake_build
+cmake --build redhat-linux-build --verbose
 
 %install
 %cmake_install

--- a/rpm/xrootd-s3-http.spec
+++ b/rpm/xrootd-s3-http.spec
@@ -20,6 +20,7 @@ BuildRequires: xrootd-server-devel >= 1:%{xrootd_current_major}
 BuildRequires: xrootd-server-devel <  1:%{xrootd_next_major}
 BuildRequires: libcurl-devel
 BuildRequires: openssl-devel
+BuildRequires: tinyxml2-devel
 
 Requires: xrootd-server >= 1:%{xrootd_current_major}.%{xrootd_current_minor}
 Requires: xrootd-server <  1:%{xrootd_next_major}.0.0-1

--- a/rpm/xrootd-s3-http.spec
+++ b/rpm/xrootd-s3-http.spec
@@ -1,5 +1,5 @@
 Name:		xrootd-s3-http
-Version:        0.2.0
+Version:        0.2.1
 Release:        1%{?dist}
 Summary:        S3/HTTP filesystem plugins for xrootd
 
@@ -45,7 +45,7 @@ cmake --build redhat-linux-build --verbose
 %license LICENSE
 
 %changelog
-* Sat Feb 1 2025 Brian Bockelman <bbockelman@morgridge.org> - 0.2.0-1
+* Sat Feb 1 2025 Brian Bockelman <bbockelman@morgridge.org> - 0.2.1-1
 - Bump to upstream version 0.2.1.
 
 * Tue Nov 28 2023 Justin Hiemstra <jhiemstra@wisc.edu> - 0.0.2-1


### PR DESCRIPTION
We want a buildable RPM for use in the upstream Pelican Dockerfile -- here's an attempt for a future 0.2.1.