### PR TITLE
Increase the timeout when waiting for the xrootd server to start

### DIFF
--- a/test/s3-setup.sh
+++ b/test/s3-setup.sh
@@ -167,7 +167,7 @@ while [ -z "$MINIO_URL" ]; do
   if [ $IDX -gt 1 ]; then
     echo "Waiting for minio to start ($IDX seconds so far) ..."
   fi
-  if [ $IDX -eq 10 ]; then
+  if [ $IDX -eq 60 ]; then
     echo "minio failed to start - failing"
     exit 1
   fi

--- a/test/xrdhttp-setup.sh
+++ b/test/xrdhttp-setup.sh
@@ -189,7 +189,7 @@ while [ -z "$XROOTD_URL" ]; do
   if [ $IDX -gt 1 ]; then
     echo "Waiting for xrootd to start ($IDX seconds so far) ..."
   fi
-  if [ $IDX -eq 10 ]; then
+  if [ $IDX -eq 60 ]; then
     echo "xrootd failed to start - failing"
     exit 1
   fi


### PR DESCRIPTION
10 seconds is not always sufficient.
Here is a test run on ricci.debian.org, the Debian riscv64 porter box with an increased timeout:
```
    22: xrootd daemon PID: 4157210
    22: XRootD logs are available at /.../xrootd-s3-http-0.2.1/obj-riscv64-linux-gnu/tests/basic/server.log
    22: Waiting for xrootd to start (2 seconds so far) ...
    22: Waiting for xrootd to start (3 seconds so far) ...
    22: Waiting for xrootd to start (4 seconds so far) ...
    [ ... ]
    22: Waiting for xrootd to start (25 seconds so far) ...
    22: Waiting for xrootd to start (26 seconds so far) ...
    22: Waiting for xrootd to start (27 seconds so far) ...
    22: xrootd started at https://ricci:39891/
```
The test log and the server log from the test are attached.

[testlog.txt](https://github.com/user-attachments/files/18634186/testlog.txt)
[server.log](https://github.com/user-attachments/files/18634187/server.log)
