### PR TITLE
Use GNUInstallDirs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,11 +100,11 @@ else()
   set_target_properties(XrdHTTPServer PROPERTIES OUTPUT_NAME "XrdHTTPServer-${XRootD_PLUGIN_VERSION}" SUFFIX ".so")
 endif()
 
-SET(LIB_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/lib" CACHE PATH "Install path for libraries")
+include(GNUInstallDirs)
 
 install(
   TARGETS XrdS3 XrdHTTPServer
-  LIBRARY DESTINATION ${LIB_INSTALL_DIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
 
 if( BUILD_TESTING )


### PR DESCRIPTION
Requires less manual configuration. Gets the /lib and /lib64 correct without extra options on the command line.