### PR TITLE
Bugfixes around stalls and file corruption

### DIFF
--- a/src/CurlUtil.cc
+++ b/src/CurlUtil.cc
@@ -243,8 +243,8 @@ void CurlWorker::Run() {
 		if (now >= next_marker) {
 			if (m_logger.getMsgMask() & LogMask::Debug) {
 				std::stringstream ss;
-				ss << "Curl worker thread " << getpid() << " is running "
-				   << running_handles << " operations";
+				ss << "Curl worker thread is running " << running_handles
+				   << " operations";
 				m_logger.Log(LogMask::Debug, "CurlWorker", ss.str().c_str());
 			}
 			last_marker = now;

--- a/src/CurlUtil.cc
+++ b/src/CurlUtil.cc
@@ -60,6 +60,7 @@ CURL *HandlerQueue::GetHandle() {
 
 	curl_easy_setopt(result, CURLOPT_USERAGENT, "xrootd-s3/0.4.0");
 	curl_easy_setopt(result, CURLOPT_BUFFERSIZE, 32 * 1024);
+	curl_easy_setopt(result, CURLOPT_NOSIGNAL, 1L);
 
 	return result;
 }

--- a/src/HTTPCommands.hh
+++ b/src/HTTPCommands.hh
@@ -195,17 +195,16 @@ class HTTPRequest {
 	XrdSysError &m_log;
 
   private:
-	enum class CurlResult { Ok, Fail, Retry };
-
 	virtual bool SetupHandle(
 		CURL *curl); // Configure the curl handle to be used by a given request.
 
 	virtual bool
 	ContinueHandle(); // Continue the request processing after a pause.
 
-	CurlResult ProcessCurlResult(
+	void ProcessCurlResult(
 		CURL *curl,
 		CURLcode rv); // Process a curl command that ran to completion.
+
 	bool
 	Fail(const std::string &ecode,
 		 const std::string &emsg); // Record a failure occurring for the request
@@ -275,7 +274,6 @@ class HTTPRequest {
 	std::string_view m_result_buffer;
 	CURL *m_curl_handle{nullptr}; // The curl handle for the ongoing request
 	char m_errorBuffer[CURL_ERROR_SIZE]; // Static error buffer for libcurl
-	unsigned m_retry_count{0};
 
 	// Time when the last request was sent on this object; used to determine
 	// whether the operation has timed out.

--- a/src/HTTPCommands.hh
+++ b/src/HTTPCommands.hh
@@ -268,7 +268,7 @@ class HTTPRequest {
 	std::chrono::steady_clock::time_point m_last_movement;
 	// Transfer stall timeout
 	static constexpr std::chrono::steady_clock::duration m_transfer_stall{
-		std::chrono::seconds(10)};
+		std::chrono::seconds(9)};
 
 	// The contents of a successful GET request.
 	std::string_view m_result_buffer;

--- a/src/S3File.hh
+++ b/src/S3File.hh
@@ -153,8 +153,8 @@ class S3File : public XrdOssDF {
 	std::string m_object;
 	S3AccessInfo m_ai;
 
-	off_t content_length;
-	time_t last_modified;
+	off_t content_length{-1};
+	time_t last_modified{-1};
 
 	static const size_t m_s3_part_size =
 		100'000'000; // The size of each S3 chunk.
@@ -162,8 +162,9 @@ class S3File : public XrdOssDF {
 	// Size of the buffer associated with the cache
 	static size_t m_cache_entry_size;
 
+	bool m_is_open{false}; // File open state
 	bool m_create{false};
-	int partNumber;
+	int partNumber{1};
 	size_t m_part_written{
 		0}; // Number of bytes written for the current upload chunk.
 	size_t m_part_size{0};	 // Size of the current upload chunk (0 if unknon);


### PR DESCRIPTION
This branch aggregates several bugfixes found while debugging failures on a specific workflow, including:
- Stall timeouts weren't working.
- Rate limiting would result in corrupt data being sent back to the client.
- HEAD was invoked twice on file open.
- libcurl was not put into threadsafe mode, potentially triggering deadlocks or long unresponsive periods.