### PR TITLE
Always assign `partial` when returning `true`

### DIFF
--- a/src/Filter.cc
+++ b/src/Filter.cc
@@ -434,6 +434,7 @@ bool FilterFileSystem::GlobOne(const std::filesystem::path &path,
 			// If the globstar is at the end of the glob, then we match
 			// any subsequent part of the path.
 			if (++cur_glob_component == glob.m_glob.end()) {
+				partial = false;
 				return true;
 			} else {
 				// To evaluate the globstar, we compare the remainder of the
@@ -489,6 +490,7 @@ bool FilterFileSystem::GlobOne(const std::filesystem::path &path,
 					if (GlobOne(subpath, {glob.m_match_dotfile, new_glob},
 								subpartial)) {
 						if (!subpartial && !path_prefix_has_dotfile) {
+							partial = false;
 							return true;
 						} else if (path_prefix_has_dotfile) {
 							potential_match = false;


### PR DESCRIPTION
```
[ RUN      ] FileSystemGlob.Globstar
=====> filter.glob /prefix1 /prefix2/*.txt
=====> filter.glob /prefix3/*/*.txt
=====> filter.prefix /prefix5
=====> filter.trace all
250608 01:04:48 8741 filter_Config: Will permit glob /prefix1
250608 01:04:48 8741 filter_Config: Will permit glob /prefix2/*.txt
250608 01:04:48 8741 filter_Config: Will permit glob /prefix3/*/*.txt
250608 01:04:48 8741 filter_Config: Will permit glob /prefix5/** all
250608 01:04:48 8741 filter_Initialize: FilterFileSystem initialized
250608 01:04:48 8741 FileSystemGlobGlobstar: Testing /some/path
./test/filter_tests.cc:385: Failure
Value of: partial
  Actual: true
Expected: false

[  FAILED  ] FileSystemGlob.Globstar (0 ms)
```
