### PR TITLE
Create a "Persist on Successful Close" plugin

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
       # Note the current convention is to use the -S and -B options here to specify source
       # and build directories, but this is only available with CMake 3.13 and higher.
       # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_TESTING=yes -DXROOTD_PLUGINS_EXTERNAL_GTEST=${{ matrix.external-gtest }}
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DENABLE_TESTS=yes -DENABLE_ASAN=true -DXROOTD_PLUGINS_EXTERNAL_GTEST=${{ matrix.external-gtest }}
 
     - name: Build
       working-directory: ${{runner.workspace}}/build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,14 +33,21 @@ jobs:
       with:
         go-version: '1.23.5'
     - name: install deps
+      working-directory: ${{runner.workspace}}
       run: |
-        sudo curl -L https://xrootd.web.cern.ch/repo/RPM-GPG-KEY.txt -o /etc/apt/trusted.gpg.d/xrootd.asc
-        sudo /bin/sh -c 'echo "deb https://xrootd.web.cern.ch/ubuntu noble stable" >> /etc/apt/sources.list.d/xrootd.list'
-        sudo apt update && sudo apt-get install -y cmake libcurl4-openssl-dev libcurl4 pkg-config libssl-dev xrootd-server libxrootd-dev libxrootd-server-dev libgtest-dev
-        sudo curl -L https://dl.min.io/server/minio/release/linux-amd64/minio -o /usr/local/bin/minio
-        sudo chmod +x /usr/local/bin/minio
-        sudo curl -L https://dl.min.io/client/mc/release/linux-amd64/mc -o /usr/local/bin/mc
-        sudo chmod +x /usr/local/bin/mc
+        # Build deps
+        sudo apt update && sudo apt-get install -y cmake libz-dev uuid-dev libcurl4-openssl-dev libcurl4 pkg-config libssl-dev g++ libscitokens-dev libgtest-dev
+
+        # Build our preferred set of patches on xrootd
+        git clone https://github.com/xrootd/xrootd.git
+        cd xrootd
+        git remote add github_pelican https://github.com/PelicanPlatform/xrootd.git
+        git fetch github_pelican
+        git checkout -b v5.8.4-pelican -t github_pelican/v5.8.4-pelican
+        mkdir -p build/release_dir
+        cd build
+        cmake .. -DCMAKE_INSTALL_PREFIX=$PWD/release_dir -DENABLE_ASAN=TRUE
+        make -j $(($(nproc) + 2)) install
 
     - name: Create Build Environment
       # Some projects don't allow in-source building, so create a separate build directory
@@ -48,14 +55,9 @@ jobs:
       run: cmake -E make_directory ${{runner.workspace}}/build
 
     - name: Configure CMake
-      # Use a bash shell so we can use the same syntax for environment variable
-      # access regardless of the host operating system
       shell: bash
       working-directory: ${{runner.workspace}}/build
-      # Note the current convention is to use the -S and -B options here to specify source
-      # and build directories, but this is only available with CMake 3.13 and higher.
-      # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DENABLE_TESTS=yes -DENABLE_ASAN=true -DXROOTD_PLUGINS_EXTERNAL_GTEST=${{ matrix.external-gtest }}
+      run: CMAKE_PREFIX_PATH=$PWD/../xrootd/build/release_dir/lib/cmake/XRootD cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DENABLE_TESTS=yes -DENABLE_ASAN=true -DXROOTD_PLUGINS_EXTERNAL_GTEST=${{ matrix.external-gtest }}
 
     - name: Build
       working-directory: ${{runner.workspace}}/build
@@ -73,7 +75,7 @@ jobs:
     - name: Start xrootd
       working-directory: ${{runner.workspace}}/build
       shell: bash
-      run: xrootd -c ${{runner.workspace}}/xrootd-s3-http/test/s3-xrootd-test.cfg &
+      run: ASAN_OPTIONS=detect_odr_violation=0 LD_LIBRARY_PATH=$PWD/../xrootd/build/release_dir/lib $PWD/../xrootd/build/release_dir/bin/xrootd -c ${{runner.workspace}}/xrootd-s3-http/test/s3-xrootd-test.cfg &
 
     - name: Get a file
       working-directory: ${{runner.workspace}}/build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,7 +178,7 @@ endif()
 include(GNUInstallDirs)
 
 install(
-  TARGETS XrdS3 XrdHTTPServer XrdOssS3 XrdOssHttp XrdOssFilter XrdOssGlobus
+  TARGETS XrdS3 XrdHTTPServer XrdOssS3 XrdOssHttp XrdOssFilter XrdOssGlobus XrdOssPosc
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
 
@@ -199,7 +199,7 @@ if( ENABLE_TESTS )
   add_library(XrdOssGlobusTesting SHARED "$<TARGET_OBJECTS:XrdOssGlobusObj>")
   target_link_libraries(XrdOssGlobusTesting XrdOssGlobusObj)
   target_include_directories(XrdOssGlobusTesting INTERFACE ${XRootD_INCLUDE_DIRS})
-  
+
   add_library( XrdOssPoscTesting SHARED "$<TARGET_OBJECTS:XrdOssPoscObj>" )
   target_link_libraries( XrdOssPoscTesting XrdOssPoscObj )
   target_include_directories( XrdOssPoscTesting INTERFACE ${XRootD_INCLUDE_DIRS} )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,6 +146,16 @@ target_link_libraries(XrdOssGlobusObj ${XRootD_UTILS_LIBRARIES} ${XRootD_SERVER_
 add_library(XrdOssGlobus MODULE "$<TARGET_OBJECTS:XrdOssGlobusObj>")
 target_link_libraries(XrdOssGlobus XrdOssGlobusObj)
 
+#######################
+## libXrdOssPosc     ##
+#######################
+add_library( XrdOssPoscObj OBJECT src/Posc.cc )
+set_target_properties( XrdOssPoscObj PROPERTIES POSITION_INDEPENDENT_CODE ON )
+target_link_libraries( XrdOssPoscObj XRootD::XrdServer XRootD::XrdUtils )
+
+add_library( XrdOssPosc MODULE "$<TARGET_OBJECTS:XrdOssPoscObj>" )
+target_link_libraries( XrdOssPosc XrdOssPoscObj )
+
 # Customize module's suffix and, on Linux, hide unnecessary symbols
 if( APPLE )
   set_target_properties( XrdS3 PROPERTIES OUTPUT_NAME "XrdS3-${XRootD_PLUGIN_VERSION}" SUFFIX ".so" )
@@ -154,6 +164,7 @@ if( APPLE )
   set_target_properties( XrdOssHttp PROPERTIES OUTPUT_NAME "XrdOssHttp-${XRootD_PLUGIN_VERSION}" SUFFIX ".so" )
   set_target_properties( XrdOssFilter PROPERTIES OUTPUT_NAME "XrdOssFilter-${XRootD_PLUGIN_VERSION}" SUFFIX ".so" )
   set_target_properties( XrdOssGlobus PROPERTIES OUTPUT_NAME "XrdOssGlobus-${XRootD_PLUGIN_VERSION}" SUFFIX ".so" )
+  set_target_properties( XrdOssPosc PROPERTIES OUTPUT_NAME "XrdOssPosc-${XRootD_PLUGIN_VERSION}" SUFFIX ".so" )
 else()
   set_target_properties( XrdS3 PROPERTIES OUTPUT_NAME "XrdS3-${XRootD_PLUGIN_VERSION}" SUFFIX ".so" LINK_FLAGS "-Wl,--version-script=${CMAKE_SOURCE_DIR}/configs/export-lib-symbols" )
   set_target_properties( XrdHTTPServer PROPERTIES OUTPUT_NAME "XrdHTTPServer-${XRootD_PLUGIN_VERSION}" SUFFIX ".so" LINK_FLAGS "-Wl,--version-script=${CMAKE_SOURCE_DIR}/configs/export-lib-symbols" )
@@ -161,6 +172,7 @@ else()
   set_target_properties( XrdOssHttp PROPERTIES OUTPUT_NAME "XrdOssHttp-${XRootD_PLUGIN_VERSION}" SUFFIX ".so" LINK_FLAGS "-Wl,--version-script=${CMAKE_SOURCE_DIR}/configs/export-lib-symbols" )
   set_target_properties( XrdOssFilter PROPERTIES OUTPUT_NAME "XrdOssFilter-${XRootD_PLUGIN_VERSION}" SUFFIX ".so" LINK_FLAGS "-Wl,--version-script=${CMAKE_SOURCE_DIR}/configs/export-lib-symbols" )
   set_target_properties( XrdOssGlobus PROPERTIES OUTPUT_NAME "XrdOssGlobus-${XRootD_PLUGIN_VERSION}" SUFFIX ".so" LINK_FLAGS "-Wl,--version-script=${CMAKE_SOURCE_DIR}/configs/export-lib-symbols" )
+  set_target_properties( XrdOssPosc PROPERTIES OUTPUT_NAME "XrdOssPosc-${XRootD_PLUGIN_VERSION}" SUFFIX ".so" LINK_FLAGS "-Wl,--version-script=${CMAKE_SOURCE_DIR}/configs/export-lib-symbols" )
 endif()
 
 include(GNUInstallDirs)
@@ -187,6 +199,10 @@ if( ENABLE_TESTS )
   add_library(XrdOssGlobusTesting SHARED "$<TARGET_OBJECTS:XrdOssGlobusObj>")
   target_link_libraries(XrdOssGlobusTesting XrdOssGlobusObj)
   target_include_directories(XrdOssGlobusTesting INTERFACE ${XRootD_INCLUDE_DIRS})
+  
+  add_library( XrdOssPoscTesting SHARED "$<TARGET_OBJECTS:XrdOssPoscObj>" )
+  target_link_libraries( XrdOssPoscTesting XrdOssPoscObj )
+  target_include_directories( XrdOssPoscTesting INTERFACE ${XRootD_INCLUDE_DIRS} )
 
   find_program(GoWrk go-wrk HINTS "$ENV{HOME}/go/bin")
   if( NOT GoWrk )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project( xrootd-http/s3 )
 
 option( XROOTD_PLUGINS_EXTERNAL_GTEST "Use an external/pre-installed copy of GTest" OFF )
 option( VALGRIND "Run select unit tests under valgrind" OFF )
-option( ASAN "Build the plugin with the address sanitizer" OFF )
+option( ENABLE_ASAN "Build the plugin with the address sanitizer" OFF )
 
 set( CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake )
 if( "${CMAKE_BUILD_TYPE}" STREQUAL "" )
@@ -20,7 +20,7 @@ if(VALGRIND)
   find_program(VALGRIND_BIN valgrind REQUIRED)
 endif()
 
-if(ASAN)
+if( ENABLE_ASAN )
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=address")
   set(CMAKE_LINKER_FLAGS "${CMAKE_LINKER_FLAGS} -fsanitize=address")
@@ -170,7 +170,7 @@ install(
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
 
-if( BUILD_TESTING )
+if( ENABLE_TESTS )
   # Create shared libraries for testing from the existing objects
   add_library(XrdS3Testing SHARED "$<TARGET_OBJECTS:XrdS3Obj>")
   target_link_libraries(XrdS3Testing XrdS3Obj)

--- a/rpm/xrootd-s3-http.spec
+++ b/rpm/xrootd-s3-http.spec
@@ -45,6 +45,7 @@ cmake --build redhat-linux-build --verbose
 %{_libdir}/libXrdOssGlobus-5.so
 %{_libdir}/libXrdOssS3-5.so
 %{_libdir}/libXrdOssFilter-5.so
+%{_libdir}/libXrdOssPosc-5.so
 %doc README.md
 %license LICENSE
 

--- a/src/AWSCredential.hh
+++ b/src/AWSCredential.hh
@@ -17,6 +17,8 @@
  ***************************************************************/
 #pragma once
 
+#include <string>
+
 class AWSCredential {
 
   public:

--- a/src/Posc.cc
+++ b/src/Posc.cc
@@ -1,0 +1,841 @@
+/***************************************************************
+ *
+ * Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+#include "Posc.hh"
+#include "logging.hh"
+
+#include <XrdOuc/XrdOucEnv.hh>
+#include <XrdOuc/XrdOucGatherConf.hh>
+#include <XrdSec/XrdSecEntity.hh>
+#include <XrdSec/XrdSecEntityAttr.hh>
+#include <XrdSys/XrdSysError.hh>
+#include <XrdVersion.hh>
+
+#include <fcntl.h>
+#include <sstream>
+#include <thread>
+
+using namespace XrdHTTPServer;
+
+PoscFile *PoscFile::m_first = nullptr;
+std::mutex PoscFile::m_list_mutex;
+std::chrono::steady_clock::duration PoscFile::m_posc_file_update =
+	std::chrono::minutes(19);
+std::chrono::steady_clock::duration PoscFileSystem::m_posc_file_timeout =
+	std::chrono::hours(1);
+
+std::once_flag PoscFileSystem::m_expiry_launch;
+std::mutex PoscFileSystem::m_shutdown_lock;
+std::condition_variable PoscFileSystem::m_shutdown_requested_cv;
+std::condition_variable PoscFileSystem::m_shutdown_complete_cv;
+bool PoscFileSystem::m_shutdown_requested = false;
+bool PoscFileSystem::m_shutdown_complete =
+	true; // Starts in "true" state as the thread hasn't started
+
+PoscFileSystem::PoscFileSystem(XrdOss *oss, std::unique_ptr<XrdSysError> log,
+							   const char *configName, XrdOucEnv *envP)
+	: XrdOssWrapper(*oss), m_oss(oss), m_log(std::move(log)) {
+	if (!Config(configName)) {
+		m_log->Emsg("Initialize", "Failed to configure the POSC layer");
+		throw std::runtime_error("Failed to configure the POSC layer");
+	}
+	InitPosc();
+}
+
+PoscFileSystem::PoscFileSystem(XrdOss *oss, std::unique_ptr<XrdSysError> log,
+							   const std::string &posc_dir, LogMask log_mask)
+	: XrdOssWrapper(*oss), m_oss(oss), m_log(std::move(log)) {
+	m_log->setMsgMask(log_mask);
+	InitPosc();
+}
+
+void PoscFileSystem::InitPosc() {
+	std::call_once(m_expiry_launch, [&] {
+		{
+			std::unique_lock lock(m_shutdown_lock);
+			if (m_shutdown_requested) {
+				m_log->Emsg("Initialize",
+							"POSC expiry thread already requested shutdown");
+				return;
+			}
+			m_shutdown_complete = false;
+		}
+		std::thread t(PoscFileSystem::ExpireThread, this);
+		t.detach();
+	});
+
+	m_log->Emsg("Initialize", "PoscFileSystem initialized");
+}
+
+PoscFileSystem::~PoscFileSystem() {}
+
+int PoscFileSystem::Chmod(const char *path, mode_t mode, XrdOucEnv *env) {
+	return VerifyPath(path, &XrdOss::Chmod, path, mode, env);
+}
+
+bool PoscFileSystem::Config(const char *configfn) {
+	m_log->setMsgMask(LogMask::Error | LogMask::Warning);
+
+	XrdOucGatherConf poscConf("posc.prefix posc.trace", m_log.get());
+	int result;
+	if ((result = poscConf.Gather(configfn, XrdOucGatherConf::trim_lines)) <
+		0) {
+		m_log->Emsg("Config", -result, "parsing config file", configfn);
+		return false;
+	}
+
+	char *val;
+	while (poscConf.GetLine()) {
+		val = poscConf.GetToken();
+		if (!strcmp(val, "trace")) {
+			m_log->setMsgMask(0);
+			if (!(val = poscConf.GetToken())) {
+				m_log->Emsg("Config",
+							"posc.trace requires an argument.  Usage: "
+							"posc.trace [all|error|warning|info|debug|none]");
+				return false;
+			}
+			do {
+				if (!strcmp(val, "all")) {
+					m_log->setMsgMask(m_log->getMsgMask() | LogMask::All);
+				} else if (!strcmp(val, "error")) {
+					m_log->setMsgMask(m_log->getMsgMask() | LogMask::Error);
+				} else if (!strcmp(val, "warning")) {
+					m_log->setMsgMask(m_log->getMsgMask() | LogMask::Error |
+									  LogMask::Warning);
+				} else if (!strcmp(val, "info")) {
+					m_log->setMsgMask(m_log->getMsgMask() | LogMask::Error |
+									  LogMask::Warning | LogMask::Info);
+				} else if (!strcmp(val, "debug")) {
+					m_log->setMsgMask(m_log->getMsgMask() | LogMask::Error |
+									  LogMask::Warning | LogMask::Info |
+									  LogMask::Debug);
+				} else if (!strcmp(val, "none")) {
+					m_log->setMsgMask(0);
+				}
+			} while ((val = poscConf.GetToken()));
+		} else if (!strcmp(val, "prefix")) {
+			if (!(val = poscConf.GetToken())) {
+				m_log->Emsg("Config", "posc.prefix requires an argument.  "
+									  "Usage: posc.prefix posc_directory");
+				return false;
+			}
+			m_posc_dir = std::filesystem::path(val);
+			if (!m_posc_dir.is_absolute()) {
+				m_log->Emsg("Config",
+							"posc.prefix requires an absolute path.  Usage: "
+							"posc.prefix posc_directory");
+				return false;
+			}
+		} else {
+			m_log->Emsg("Config", "Unknown configuration directive", val);
+			return false;
+		}
+	}
+	if (m_posc_dir.empty()) {
+		m_log->Emsg("Config",
+					"No POSC temporary directory specified but is required. "
+					"Usage: posc.prefix posc_directory");
+		return false;
+	}
+	struct stat sb;
+	int rv;
+	if ((rv = m_oss->Stat(m_posc_dir.c_str(), &sb, 0, nullptr)) != 0) {
+		if (rv == -ENOENT) {
+			m_log->Emsg("Config", "POSC directory does not exist",
+						m_posc_dir.c_str());
+			if ((rv = m_oss->Mkdir(m_posc_dir.c_str(), 0755, 1, nullptr)) !=
+				0) {
+				m_log->Emsg("Config", "Failed to create POSC directory",
+							m_posc_dir.c_str(), strerror(-rv));
+				return false;
+			}
+			m_log->Emsg("Config", "Created POSC directory", m_posc_dir.c_str());
+		} else if (rv == -ENOTDIR) {
+		} else {
+			m_log->Emsg("Config",
+						"POSC directory does not exist or is not accessible",
+						m_posc_dir.c_str());
+			return false;
+		}
+	}
+	if (!S_ISDIR(sb.st_mode)) {
+		m_log->Emsg("Config", "POSC directory is not a directory",
+					m_posc_dir.c_str());
+		return false;
+	}
+	return true;
+}
+
+int PoscFileSystem::Create(const char *tid, const char *path, mode_t mode,
+						   XrdOucEnv &env, int opts) {
+	return VerifyPath(path, &XrdOss::Create, tid, path, mode, env, opts);
+}
+
+void PoscFileSystem::ExpireFiles() {
+	auto dp_raw = wrapPI.newDir(m_posc_dir.c_str());
+	if (!dp_raw) {
+		m_log->Emsg("ExpireFiles",
+					"Failed to create directory object for POSC directory");
+		return;
+	}
+	std::unique_ptr<XrdOssDF> dp(dp_raw);
+	XrdOucEnv env;
+	if (dp->Opendir(m_posc_dir.c_str(), env) != 0) {
+		m_log->Emsg("ExpireFiles", "Failed to open POSC directory",
+					m_posc_dir.c_str());
+		return;
+	}
+
+	int rv;
+	char buff[PATH_MAX];
+	while ((rv = dp->Readdir(buff, PATH_MAX)) == 0) {
+		if (buff[0] == '\0') {
+			// No more entries
+			break;
+		}
+		if (!strcmp(buff, ".") || !strcmp(buff, "..") || buff[0] == '.') {
+			// Skip current, parent, and hidden directory entries
+			continue;
+		}
+		struct stat sb;
+		if (dp->StatRet(&sb) == 0) {
+			if (sb.st_mode & S_IFDIR) {
+				ExpireUserFiles(buff);
+			}
+		}
+	}
+	if (rv) {
+		m_log->Emsg("ExpireFiles", "Error reading POSC directory",
+					m_posc_dir.c_str(), strerror(-rv));
+	}
+	dp->Close();
+}
+
+void PoscFileSystem::ExpireThread(PoscFileSystem *fs) {
+	while (true) {
+		{
+			std::unique_lock lock(m_shutdown_lock);
+			m_shutdown_requested_cv.wait_for(lock, std::chrono::seconds(5), [] {
+				return m_shutdown_requested;
+			});
+			if (m_shutdown_requested) {
+				break;
+			}
+		}
+
+		PoscFile::UpdateOpenFiles();
+
+		fs->ExpireFiles();
+	}
+	std::unique_lock lock(m_shutdown_lock);
+	m_shutdown_complete = true;
+	m_shutdown_complete_cv.notify_one();
+}
+
+void PoscFileSystem::ExpireUserFiles(const char *username) {
+	auto user_posc_dir = m_posc_dir / username;
+
+	auto dp_raw = wrapPI.newDir(user_posc_dir.c_str());
+	if (!dp_raw) {
+		m_log->Emsg("ExpireUserFiles",
+					"Failed to create directory object for POSC user directory",
+					user_posc_dir.c_str());
+		return;
+	}
+	std::unique_ptr<XrdOssDF> dp(dp_raw);
+	XrdOucEnv env;
+	if (dp->Opendir(user_posc_dir.c_str(), env) != 0) {
+		m_log->Emsg("ExpireUserFiles", "Failed to open POSC user directory",
+					user_posc_dir.c_str());
+		return;
+	}
+	int rv;
+	char buff[PATH_MAX];
+	auto oldest_acceptable =
+		time(NULL) -
+		std::chrono::duration_cast<std::chrono::seconds>(m_posc_file_timeout)
+			.count();
+	while ((rv = dp->Readdir(buff, PATH_MAX)) == 0) {
+		if (buff[0] == '\0') {
+			// No more entries
+			break;
+		}
+		if (strncmp(buff, "in_progress.", strlen("in_progress."))) {
+			// Skip current, parent, and hidden directory entries
+			continue;
+		}
+		struct stat sb;
+		if ((rv = dp->StatRet(&sb))) {
+			m_log->Emsg("ExpireUserFiles", "Failed to stat POSC file", buff,
+						strerror(-rv));
+			continue;
+		}
+
+		if (sb.st_mode & S_IFDIR) {
+			// Skip directories
+			continue;
+		}
+		if (sb.st_mtime >= oldest_acceptable) {
+			// File is still in use, skip it
+			continue;
+		}
+
+		// File is stale, remove it
+		auto full_path = user_posc_dir / buff;
+		if ((rv = Unlink(full_path.c_str(), 0, &env)) != 0) {
+			m_log->Emsg("ExpireUserFiles", "Failed to remove stale POSC file",
+						full_path.c_str(), strerror(-rv));
+			continue;
+		}
+		m_log->Log(LogMask::Debug, "POSC", "Removed stale POSC file",
+				   full_path.c_str());
+	}
+	if (rv) {
+		m_log->Emsg("ExpireFiles", "Error reading POSC directory",
+					m_posc_dir.c_str(), strerror(-rv));
+	}
+	dp->Close();
+}
+
+bool PoscFileSystem::InPoscDir(const std::filesystem::path &path) const {
+	auto path_iter = path.begin();
+	for (auto posc_dir_iter = m_posc_dir.begin();
+		 posc_dir_iter != m_posc_dir.end(); ++posc_dir_iter, ++path_iter) {
+		// The path has fewer components than our storage directory; hence it is
+		// not contained inside.
+		if (path_iter == path.end()) {
+			return false;
+		}
+		if (*posc_dir_iter != *path_iter) {
+			return false;
+		}
+	}
+	// In this case, the path has more components than the POSC directory and
+	// all of the components match, so it is inside.
+	return true;
+}
+
+std::string PoscFileSystem::GeneratePoscFile(const char *path, XrdOucEnv &env) {
+	std::filesystem::path posc_filename = m_posc_dir;
+	if (env.secEnv() && env.secEnv()->name && (*env.secEnv()->name) != '\0') {
+		posc_filename /= env.secEnv()->name;
+	} else {
+		posc_filename /= "anonymous";
+	}
+	posc_filename /= "in_progress." + std::to_string(time(NULL)) + "." +
+					 std::to_string(rand() % 1000000);
+
+	return posc_filename.string();
+}
+
+int PoscFileSystem::Lfn2Pfn(const char *Path, char *buff, int blen) {
+	return VerifyPath(Path,
+					  static_cast<int (XrdOss::*)(const char *, char *, int)>(
+						  &XrdOss::Lfn2Pfn),
+					  Path, buff, blen);
+}
+
+const char *PoscFileSystem::Lfn2Pfn(const char *Path, char *buff, int blen,
+									int &rc) {
+	if (InPoscDir(Path)) {
+		rc = -ENOENT;
+		return nullptr;
+	}
+	return wrapPI.Lfn2Pfn(Path, buff, blen, rc);
+}
+
+int PoscFileSystem::Mkdir(const char *path, mode_t mode, int mkpath,
+						  XrdOucEnv *envP) {
+	return VerifyPath(path, &XrdOss::Mkdir, path, mode, mkpath, envP);
+}
+
+XrdOssDF *PoscFileSystem::newFile(char const *user) {
+	std::unique_ptr<XrdOssDF> wrapped(m_oss->newFile(user));
+	return new PoscFile(std::move(wrapped), *m_log, *this);
+}
+
+XrdOssDF *PoscFileSystem::newDir(char const *user) {
+	std::unique_ptr<XrdOssDF> wrapped(m_oss->newDir(user));
+	return new PoscDir(std::move(wrapped), *m_log, *this);
+}
+
+int PoscFileSystem::Reloc(const char *tident, const char *path,
+						  const char *cgName, const char *anchor) {
+	if (!path || !cgName) {
+		return -ENOENT;
+	}
+
+	if (InPoscDir(path)) {
+		m_log->Log(LogMask::Debug, "POSC",
+				   "Failing relocation as source path is in POSC directory",
+				   path);
+		return -ENOENT;
+	}
+	if (InPoscDir(cgName)) {
+		m_log->Log(LogMask::Debug, "Glob",
+				   "Failing relocation as destination path in POSC directory",
+				   cgName);
+		return -ENOENT;
+	}
+
+	return wrapPI.Reloc(tident, path, cgName, anchor);
+}
+
+int PoscFileSystem::Remdir(const char *path, int Opts, XrdOucEnv *envP) {
+	return VerifyPath(path, &XrdOss::Remdir, path, Opts, envP);
+}
+
+int PoscFileSystem::Rename(const char *oPath, const char *nPath,
+						   XrdOucEnv *oEnvP, XrdOucEnv *nEnvP) {
+	if (!oPath || !nPath) {
+		return -ENOENT;
+	}
+
+	if (InPoscDir(oPath)) {
+		m_log->Log(LogMask::Debug, "POSC",
+				   "Failing rename as source path in POSC directory", oPath);
+		return -ENOENT;
+	}
+	if (InPoscDir(oPath)) {
+		m_log->Log(LogMask::Debug, "POSC",
+				   "Failing rename as destination path in POSC directory",
+				   nPath);
+		return -ENOENT;
+	}
+
+	return wrapPI.Rename(oPath, nPath, oEnvP, nEnvP);
+}
+
+void PoscFileSystem::Shutdown() {
+	std::unique_lock lock(m_shutdown_lock);
+	m_shutdown_requested = true;
+	m_shutdown_requested_cv.notify_one();
+
+	m_shutdown_complete_cv.wait(lock, [] { return m_shutdown_complete; });
+}
+
+int PoscFileSystem::Stat(const char *path, struct stat *buff, int opts,
+						 XrdOucEnv *env) {
+	return VerifyPath(path, &XrdOss::Stat, path, buff, opts, env);
+}
+
+int PoscFileSystem::StatFS(const char *path, char *buff, int &blen,
+						   XrdOucEnv *env) {
+	return VerifyPath(path, &XrdOss::StatFS, path, buff, blen, env);
+}
+
+int PoscFileSystem::StatLS(XrdOucEnv &env, const char *path, char *buff,
+						   int &blen) {
+	return VerifyPath(path, &XrdOss::StatLS, env, path, buff, blen);
+}
+
+int PoscFileSystem::StatPF(const char *path, struct stat *buff, int opts) {
+	return VerifyPath(
+		path,
+		static_cast<int (XrdOss::*)(const char *, struct stat *, int)>(
+			&XrdOss::StatPF),
+		path, buff, opts);
+}
+
+int PoscFileSystem::StatPF(const char *path, struct stat *buff) {
+	return VerifyPath(path,
+					  static_cast<int (XrdOss::*)(const char *, struct stat *)>(
+						  &XrdOss::StatPF),
+					  path, buff);
+}
+
+int PoscFileSystem::StatVS(XrdOssVSInfo *vsP, const char *sname, int updt) {
+	return VerifyPath(sname, &XrdOss::StatVS, vsP, sname, updt);
+}
+
+int PoscFileSystem::StatXA(const char *path, char *buff, int &blen,
+						   XrdOucEnv *env) {
+	return VerifyPath(path, &XrdOss::StatXA, path, buff, blen, env);
+}
+
+int PoscFileSystem::StatXP(const char *path, unsigned long long &attr,
+						   XrdOucEnv *env) {
+	return VerifyPath(path, &XrdOss::StatXP, path, attr, env);
+}
+
+int PoscFileSystem::Truncate(const char *path, unsigned long long fsize,
+							 XrdOucEnv *env) {
+	return VerifyPath(path, &XrdOss::Truncate, path, fsize, env);
+}
+
+int PoscFileSystem::Unlink(const char *path, int Opts, XrdOucEnv *env) {
+	return VerifyPath(path, &XrdOss::Unlink, path, Opts, env);
+}
+
+template <class Fn, class... Args>
+int PoscFileSystem::VerifyPath(std::string_view path, Fn &&fn, Args &&...args) {
+	if (!InPoscDir(path)) {
+		m_log->Log(LogMask::Debug, "Posc",
+				   "Path is inside POSC directory; returning ENOENT",
+				   path.data());
+		return -ENOENT;
+	}
+
+	// Invoke the provided method `fn` on the underlying XrdOss object we are
+	// wrapping (`wrapPI`). This template is agnostic to the actual arguments to
+	// the method; they are just forwarded straight through.
+	//
+	// For example, if this object is wrapping an `S3FileSystem` object, then
+	//    ```
+	//    std::invoke(&XrdOss::Open, wrapPI, std::forward<Args>("/foo",
+	//    O_RDONLY, 0, nullptr));
+	//    ```
+	// is just a funky way of saying `wrapPI->Open("/foo", O_RDONLY, 0,
+	// nullptr);`
+	return std::invoke(fn, wrapPI, std::forward<Args>(args)...);
+}
+
+PoscDir::~PoscDir() {}
+
+int PoscDir::Opendir(const char *path, XrdOucEnv &env) {
+	if (!path) {
+		return -ENOENT;
+	}
+	if (m_oss.InPoscDir(path)) {
+		m_log.Log(LogMask::Debug, "Opendir",
+				  "Ignoring directory as it is in the POSC temporary directory",
+				  path);
+		return -ENOENT;
+	}
+	m_prefix = path;
+	return wrapDF.Opendir(path, env);
+}
+
+int PoscDir::Readdir(char *buff, int blen) {
+	m_stat_avail = false;
+	while (true) {
+		auto rc = wrapDF.Readdir(buff, blen);
+		if (rc) {
+			return rc;
+		}
+		if (*buff == '\0') {
+			return 0;
+		} else if (!strcmp(buff, ".") || !strcmp(buff, "..")) {
+			// Always permit special current and parent directory links for
+			// `Readdir`.  They allow the users of the XrdHttp web interface
+			// to navigate the directory hierarchy through the rendered HTML.
+			// If they're actually used to construct a path, they will get
+			// normalized out by the XrdOfs layer before being passed back to
+			// the XrdOss layer (this class).
+			return 0;
+		}
+		auto path = m_prefix / std::string_view(buff, strnlen(buff, blen));
+		if (m_oss.InPoscDir(path)) {
+			if (m_log.getMsgMask() & LogMask::Debug) {
+				m_log.Log(LogMask::Debug, "Readdir",
+						  "Ignoring directory component as it passes no glob",
+						  path.string().c_str());
+			}
+		} else {
+			return 0;
+		}
+	}
+}
+
+// Returns the struct stat corresponding to the current
+// directory entry name.
+//
+// If `Readdir` required a stat of the path to determine
+// if its visible, the cached copy may be served here.
+int PoscDir::StatRet(struct stat *buff) {
+	if (m_stat_avail) {
+		memcpy(buff, &m_stat, sizeof(m_stat));
+		return 0;
+	}
+	auto rc = wrapDF.StatRet(&m_stat);
+	if (!rc) {
+		m_stat_avail = true;
+		memcpy(buff, &m_stat, sizeof(m_stat));
+	}
+	return rc;
+}
+
+int PoscDir::Close(long long *retsz) {
+	m_prefix.clear();
+	return wrapDF.Close(retsz);
+}
+
+PoscFile::~PoscFile() {
+	if (m_posc_entity->name) {
+		free(m_posc_entity->name);
+	}
+	if (m_posc_entity->host) {
+		free(m_posc_entity->host);
+	}
+	if (m_posc_entity->vorg) {
+		free(m_posc_entity->vorg);
+	}
+	if (m_posc_entity->role) {
+		free(m_posc_entity->role);
+	}
+	if (m_posc_entity->grps) {
+		free(m_posc_entity->grps);
+	}
+	if (m_posc_entity->creds) {
+		free(m_posc_entity->creds);
+	}
+	if (m_posc_entity->endorsements) {
+		free(m_posc_entity->endorsements);
+	}
+	if (m_posc_entity->moninfo) {
+		free(m_posc_entity->moninfo);
+	}
+
+	std::unique_lock lock(m_list_mutex);
+	if (m_prev) {
+		m_prev->m_next = m_next;
+	}
+	if (m_next) {
+		m_next->m_prev = m_prev;
+	}
+	if (m_first == this) {
+		m_first = m_next;
+	}
+}
+
+void PoscFile::CopySecEntity(const XrdSecEntity &in) {
+	m_posc_entity.reset(new XrdSecEntity());
+	if (in.name) {
+		m_posc_entity->name = strdup(in.name);
+	}
+	if (in.host) {
+		m_posc_entity->host = strdup(in.host);
+	}
+	if (in.vorg) {
+		m_posc_entity->vorg = strdup(in.vorg);
+	}
+	if (in.role) {
+		m_posc_entity->role = strdup(in.role);
+	}
+	if (in.grps) {
+		m_posc_entity->grps = strdup(in.grps);
+	}
+	if (in.creds && in.credslen > 0) {
+		m_posc_entity->creds = strdup(in.creds);
+		m_posc_entity->credslen = in.credslen;
+	}
+	if (in.endorsements) {
+		m_posc_entity->endorsements = strdup(in.endorsements);
+	}
+	if (in.moninfo) {
+		m_posc_entity->moninfo = strdup(in.moninfo);
+	}
+
+	if (!in.eaAPI) {
+		return;
+	}
+	XrdSecEntityAttrCopy copyObj(*m_posc_entity->eaAPI);
+	in.eaAPI->List(copyObj);
+}
+
+int PoscFile::Close(long long *retsz) {
+	if (m_posc_filename.empty()) {
+		return wrapDF.Close(retsz);
+	}
+
+	auto close_rv = wrapDF.Close(retsz);
+	if (close_rv) {
+		m_oss.Unlink(m_posc_filename.c_str(), 0, m_posc_env.get());
+		return close_rv;
+	}
+
+	auto rv =
+		m_oss.Chmod(m_posc_filename.c_str(), m_posc_mode, m_posc_env.get());
+	if (rv) {
+		m_log.Log(LogMask::Error, "POSC", "Failed to set POSC file mode",
+				  m_posc_filename.c_str(), strerror(-rv));
+
+		m_oss.Unlink(m_posc_filename.c_str(), 0, m_posc_env.get());
+		return -EIO;
+	}
+
+	rv = m_oss.Rename(m_posc_filename.c_str(), m_orig_filename.c_str(),
+					  m_posc_env.get(), m_posc_env.get());
+	if (rv) {
+		std::stringstream ss;
+		ss << "Failed to rename POSC file " << m_posc_filename << " to "
+		   << m_orig_filename << ": " << strerror(-rv);
+		m_log.Log(LogMask::Error, "POSC", ss.str().c_str());
+
+		m_oss.Unlink(m_posc_filename.c_str(), 0, m_posc_env.get());
+
+		return -EIO;
+	}
+	return 0;
+}
+
+int PoscFile::Open(const char *path, int Oflag, mode_t Mode, XrdOucEnv &env) {
+	if (!m_oss.InPoscDir(path)) {
+		m_log.Log(LogMask::Debug, "POSC",
+				  "Failing file open as path is in POSC directory", path);
+		return -ENOENT;
+	}
+
+	if ((Oflag & O_CREAT) == 0) {
+		return wrapDF.Open(path, Oflag, Mode, env);
+	}
+
+	if (env.secEnv()) {
+		CopySecEntity(*env.secEnv());
+	}
+	int envlen;
+	auto envbuff = env.Env(envlen);
+	m_posc_env.reset(new XrdOucEnv(envbuff, envlen, m_posc_entity.get()));
+	m_posc_mode = Mode;
+	m_posc_mtime.store(time(NULL), std::memory_order_relaxed);
+	for (int idx = 0; idx < 10; ++idx) {
+		m_posc_filename = m_oss.GeneratePoscFile(path, env);
+
+		auto rv =
+			wrapDF.Open(m_posc_filename.c_str(), Oflag & O_EXCL, 0600, env);
+		if (rv >= 0) {
+			m_log.Log(LogMask::Debug, "POSC", "Opened POSC file",
+					  m_posc_filename.c_str());
+
+			// Add this open file to the list of POSC files.
+			std::unique_lock lock(m_list_mutex);
+			if (m_first) {
+				m_next = m_first;
+				m_first->m_prev = this;
+			}
+			m_first = this;
+
+			return rv;
+		} else if (rv == -ENOENT) {
+			// The per-user POSC directory does not exist; create it.
+			m_log.Log(LogMask::Debug, "POSC",
+					  "POSC sub-directory must be created for",
+					  m_posc_filename.c_str());
+			std::filesystem::path posc_dir =
+				std::filesystem::path(m_posc_filename).parent_path();
+			if (m_oss.Mkdir(posc_dir.c_str(), 0700, 1, &env) != 0) {
+				m_log.Log(LogMask::Error, "POSC",
+						  "Failed to create POSC sub-directory",
+						  posc_dir.c_str(), strerror(errno));
+				return -EIO;
+			}
+		} else if (rv == -EINTR) {
+			m_log.Log(LogMask::Debug, "POSC",
+					  "POSC file creation interrupted; retrying",
+					  m_posc_filename.c_str());
+		} else if (rv != -EEXIST) {
+			m_log.Log(LogMask::Error, "POSC", "Failed to open POSC file",
+					  m_posc_filename.c_str(), strerror(-rv));
+			// We expect the POSC file creation to always succeed; on failure,
+			// we assume it's an internal error and return an EIO.
+			return -EIO;
+		} else {
+			m_log.Log(LogMask::Debug, "POSC",
+					  "Temporary POSC file already exists; trying again",
+					  m_posc_filename.c_str());
+		}
+	}
+	return -EIO;
+}
+
+ssize_t PoscFile::pgWrite(void *buffer, off_t offset, size_t wrlen,
+						  uint32_t *csvec, uint64_t opts) {
+	if (!m_posc_filename.empty()) {
+		m_posc_mtime.store(time(NULL), std::memory_order_relaxed);
+	}
+	return wrapDF.pgWrite(buffer, offset, wrlen, csvec, opts);
+}
+
+int PoscFile::pgWrite(XrdSfsAio *aioparm, uint64_t opts) {
+	if (!m_posc_filename.empty()) {
+		m_posc_mtime.store(time(NULL), std::memory_order_relaxed);
+	}
+	return wrapDF.pgWrite(aioparm, opts);
+}
+
+void PoscFile::UpdateOpenFiles() {
+	auto now = std::chrono::system_clock::now();
+	struct timeval now_tv[2];
+	gettimeofday(now_tv, nullptr);
+	now_tv[0].tv_sec = now_tv[1].tv_sec;
+	now_tv[0].tv_usec = now_tv[1].tv_usec;
+
+	std::unique_lock lock(m_list_mutex);
+	for (PoscFile *file = m_first; file; file = file->m_next) {
+		if (file->m_posc_filename.empty()) {
+			continue;
+		}
+
+		auto last_update = std::chrono::system_clock::from_time_t(
+			file->m_posc_mtime.load(std::memory_order_relaxed));
+		if (now - last_update > m_posc_file_update) {
+			file->m_posc_mtime.store(time(NULL), std::memory_order_relaxed);
+
+			if (file->wrapDF.Fctl(Fctl_utimes, sizeof(now_tv),
+								  reinterpret_cast<const char *>(now_tv),
+								  nullptr) != 0) {
+				file->m_log.Log(LogMask::Error, "POSC",
+								"Failed to update POSC file mtime",
+								file->m_posc_filename.c_str(), strerror(errno));
+			} else {
+				file->m_log.Log(LogMask::Debug, "POSC",
+								"Updated POSC file mode",
+								file->m_posc_filename.c_str());
+			}
+		}
+	}
+}
+
+ssize_t PoscFile::Write(const void *buffer, off_t offset, size_t size) {
+	if (!m_posc_filename.empty()) {
+		m_posc_mtime.store(time(NULL), std::memory_order_relaxed);
+	}
+
+	return wrapDF.Write(buffer, offset, size);
+}
+
+int PoscFile::Write(XrdSfsAio *aiop) {
+	if (!m_posc_filename.empty()) {
+		m_posc_mtime.store(time(NULL), std::memory_order_relaxed);
+	}
+
+	return wrapDF.Write(aiop);
+}
+
+extern "C" {
+
+XrdVERSIONINFO(XrdOssAddStorageSystem2, Posc);
+
+XrdOss *XrdOssAddStorageSystem2(XrdOss *curr_oss, XrdSysLogger *logger,
+								const char *config_fn, const char *parms,
+								XrdOucEnv *envP) {
+
+	std::unique_ptr<XrdSysError> log(new XrdSysError(logger, "posc_"));
+	try {
+		return new PoscFileSystem(curr_oss, std::move(log), config_fn, envP);
+	} catch (std::runtime_error &re) {
+		XrdSysError tmp_log(logger, "posc_");
+		tmp_log.Emsg("Initialize",
+					 "Encountered a runtime failure when initializing the "
+					 "filter filesystem:",
+					 re.what());
+		return nullptr;
+	}
+}
+}

--- a/src/Posc.cc
+++ b/src/Posc.cc
@@ -27,6 +27,7 @@
 #include <XrdVersion.hh>
 
 #include <fcntl.h>
+#include <functional>
 #include <sstream>
 #include <thread>
 
@@ -216,8 +217,7 @@ void PoscFileSystem::ExpireFiles() {
 			continue;
 		}
 
-		XrdSecEntity secEnt;
-		memset(&secEnt, '\0', sizeof(XrdSecEntity));
+		XrdSecEntity secEnt = {};
 		secEnt.name = buff;
 		XrdOucEnv userEnv(nullptr, 0, &secEnt);
 
@@ -281,7 +281,6 @@ void PoscFileSystem::ExpireUserFiles(XrdOucEnv &env) {
 		return;
 	}
 	std::unique_ptr<XrdOssDF> dp(dp_raw);
-	XrdOucEnv env;
 	if (dp->Opendir(user_posc_dir.c_str(), env) != 0) {
 		m_log->Emsg("ExpireUserFiles", "Failed to open POSC user directory",
 					user_posc_dir.c_str());

--- a/src/Posc.hh
+++ b/src/Posc.hh
@@ -1,0 +1,241 @@
+/***************************************************************
+ *
+ * Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+#ifndef __POSC_HH_
+#define __POSC_HH_
+
+#include "logging.hh"
+
+#include <XrdOss/XrdOssWrapper.hh>
+#include <XrdSec/XrdSecEntity.hh>
+#include <XrdSec/XrdSecEntityAttr.hh>
+
+#include <chrono>
+#include <condition_variable>
+#include <filesystem>
+#include <memory>
+#include <mutex>
+#include <string_view>
+
+// Forward declarations
+class XrdSysError;
+class XrdOucEnv;
+
+class PoscFileSystem final : public XrdOssWrapper {
+  public:
+	PoscFileSystem(XrdOss *oss, std::unique_ptr<XrdSysError> log,
+				   const char *configName, XrdOucEnv *envP);
+
+	PoscFileSystem(XrdOss *oss, std::unique_ptr<XrdSysError> log,
+				   const std::string &posc_dir,
+				   XrdHTTPServer::LogMask log_mask);
+
+	virtual ~PoscFileSystem();
+
+	bool Config(const char *configfn);
+
+	XrdOssDF *newDir(const char *user = 0) override;
+	XrdOssDF *newFile(const char *user = 0) override;
+
+	virtual int Chmod(const char *path, mode_t mode,
+					  XrdOucEnv *env = 0) override;
+	virtual int Create(const char *tid, const char *path, mode_t mode,
+					   XrdOucEnv &env, int opts = 0) override;
+
+	// Generate a POSC filename for a given path.
+	// The resulting filename will be within the POSC directory and will
+	// have a high chance for being unique; unlike mkstemp however, there's
+	// no guarantee provided for uniqueness.
+	std::string GeneratePoscFile(const char *path, XrdOucEnv &env);
+
+	bool InPoscDir(const std::filesystem::path &path) const;
+
+	void InitPosc();
+
+	virtual int Mkdir(const char *path, mode_t mode, int mkpath = 0,
+					  XrdOucEnv *envP = 0) override;
+	virtual int Reloc(const char *tident, const char *path, const char *cgName,
+					  const char *anchor = 0) override;
+	virtual int Remdir(const char *path, int Opts = 0,
+					   XrdOucEnv *envP = 0) override;
+	virtual int Rename(const char *oPath, const char *nPath,
+					   XrdOucEnv *oEnvP = 0, XrdOucEnv *nEnvP = 0) override;
+	virtual int Stat(const char *path, struct stat *buff, int opts = 0,
+					 XrdOucEnv *env = 0) override;
+	virtual int StatFS(const char *path, char *buff, int &blen,
+					   XrdOucEnv *env = 0) override;
+	virtual int StatLS(XrdOucEnv &env, const char *path, char *buff,
+					   int &blen) override;
+	virtual int StatPF(const char *path, struct stat *buff, int opts) override;
+	virtual int StatPF(const char *path, struct stat *buff) override;
+	virtual int StatVS(XrdOssVSInfo *vsP, const char *sname = 0,
+					   int updt = 0) override;
+	virtual int StatXA(const char *path, char *buff, int &blen,
+					   XrdOucEnv *env = 0) override;
+	virtual int StatXP(const char *path, unsigned long long &attr,
+					   XrdOucEnv *env = 0) override;
+	virtual int Truncate(const char *path, unsigned long long fsize,
+						 XrdOucEnv *env = 0) override;
+	virtual int Unlink(const char *path, int Opts = 0,
+					   XrdOucEnv *env = 0) override;
+	virtual int Lfn2Pfn(const char *Path, char *buff, int blen) override;
+	virtual const char *Lfn2Pfn(const char *Path, char *buff, int blen,
+								int &rc) override;
+
+	std::pair<bool, std::string> SanitizePrefix(const std::filesystem::path &);
+
+	static void SetFileTimeout(std::chrono::steady_clock::duration timeout) {
+		m_posc_file_timeout = timeout;
+	}
+
+  private:
+	void ExpireFiles();
+
+	static void ExpireThread(PoscFileSystem *fs);
+
+	void ExpireUserFiles(const char *username);
+
+	// Invoked on the shutdown of the library, will trigger the background
+	// threads to wrap up and have a clean exit.
+	static void Shutdown() __attribute__((destructor));
+
+	// Verify the path is not inside the special "posc" directory
+	// where temporary files are stored.  If not, call the provided
+	// function with the extra arguments.
+	template <class Fn, class... Args>
+	int VerifyPath(std::string_view path, Fn &&fn, Args &&...args);
+
+	// The location where temporary files are stored while they are being
+	// written.
+	std::filesystem::path m_posc_dir;
+
+	// The underlying storage system we are wrapping.
+	std::unique_ptr<XrdOss> m_oss;
+	std::unique_ptr<XrdSysError> m_log;
+
+	// How long a file can be open and idle before it is considered stale
+	// and is subject to deletion.
+	static std::chrono::steady_clock::duration m_posc_file_timeout;
+
+	// Static members to manage the periodic cleanup of stale files.
+	static std::once_flag m_expiry_launch;
+	static std::mutex m_shutdown_lock;
+	static std::condition_variable m_shutdown_complete_cv;
+	static std::condition_variable m_shutdown_requested_cv;
+	static bool m_shutdown_requested;
+	static bool m_shutdown_complete;
+};
+
+class PoscFile final : public XrdOssWrapDF {
+  public:
+	PoscFile(std::unique_ptr<XrdOssDF> wrapDF, XrdSysError &log,
+			 PoscFileSystem &oss)
+		: XrdOssWrapDF(*wrapDF), m_wrapped(std::move(wrapDF)), m_log(log),
+		  m_oss(oss) {}
+
+	virtual ~PoscFile();
+
+	virtual int Close(long long *retsz = 0) override;
+
+	virtual int Open(const char *path, int Oflag, mode_t Mode,
+					 XrdOucEnv &env) override;
+
+	virtual ssize_t pgWrite(void *buffer, off_t offset, size_t wrlen,
+							uint32_t *csvec, uint64_t opts) override;
+
+	virtual int pgWrite(XrdSfsAio *aioparm, uint64_t opts) override;
+
+	static void
+	SetFileUpdateDuration(std::chrono::steady_clock::duration duration) {
+		m_posc_file_update = duration;
+	}
+
+	// Iterate through all the open PoscFile instances and update their
+	// mtime to prevent them from being deleted by the periodic cleanup
+	// of stale/abandoned file handles in the POSC directory.
+	static void UpdateOpenFiles();
+
+	virtual ssize_t Write(const void *buffer, off_t offset,
+						  size_t size) override;
+
+	virtual int Write(XrdSfsAio *aiop) override;
+
+  private:
+	class XrdSecEntityAttrCopy final : public XrdSecEntityAttrCB {
+	  public:
+		XrdSecEntityAttrCopy(XrdSecEntityAttr &dest) : m_dest(dest) {}
+
+		virtual XrdSecEntityAttrCB::Action Attr(const char *key,
+												const char *val) override {
+			m_dest.Add(key, val);
+			return XrdSecEntityAttrCB::Action::Next;
+		}
+
+	  private:
+		XrdSecEntityAttr &m_dest;
+	};
+	void CopySecEntity(const XrdSecEntity &in);
+
+	mode_t m_posc_mode{0};
+	std::unique_ptr<XrdOssDF> m_wrapped;
+	std::unique_ptr<XrdOucEnv> m_posc_env;
+	std::unique_ptr<XrdSecEntity> m_posc_entity;
+	XrdSysError &m_log;
+	PoscFileSystem &m_oss;
+	std::atomic<time_t> m_posc_mtime{0};
+	std::string m_posc_filename;
+	std::string m_orig_filename;
+
+	// Static members to keep track of all PoscFile instances.
+	// Periodically, the filesystem object will iterate through
+	// this list and update the mtime of all the open files to
+	// prevent them from being deleted.
+	static std::mutex m_list_mutex;
+	static PoscFile *m_first;
+	PoscFile *m_next{nullptr};
+	PoscFile *m_prev{nullptr};
+
+	// How long a file can be open and idle before we update its mtime
+	// to prevent it from being deleted.
+	static std::chrono::steady_clock::duration m_posc_file_update;
+};
+
+class PoscDir final : public XrdOssWrapDF {
+  public:
+	PoscDir(std::unique_ptr<XrdOssDF> wrapDF, XrdSysError &log,
+			PoscFileSystem &oss)
+		: XrdOssWrapDF(*wrapDF), m_wrapped(std::move(wrapDF)), m_log(log),
+		  m_oss(oss) {}
+
+	virtual ~PoscDir();
+
+	virtual int Opendir(const char *path, XrdOucEnv &env) override;
+	virtual int Readdir(char *buff, int blen) override;
+	virtual int StatRet(struct stat *buff) override;
+	virtual int Close(long long *retsz = 0) override;
+
+  private:
+	bool m_stat_avail{false};
+	struct stat m_stat;
+	std::unique_ptr<XrdOssDF> m_wrapped;
+	XrdSysError &m_log;
+	PoscFileSystem &m_oss;
+	std::filesystem::path m_prefix;
+};
+
+#endif // __POSC_HH_

--- a/src/Posc.hh
+++ b/src/Posc.hh
@@ -111,7 +111,7 @@ class PoscFileSystem final : public XrdOssWrapper {
   private:
 	static void ExpireThread(PoscFileSystem *fs);
 
-	void ExpireUserFiles(const char *username);
+	void ExpireUserFiles(XrdOucEnv &env);
 
 	// Invoked on the shutdown of the library, will trigger the background
 	// threads to wrap up and have a clean exit.

--- a/src/Posc.hh
+++ b/src/Posc.hh
@@ -25,6 +25,7 @@
 #include <XrdSec/XrdSecEntity.hh>
 #include <XrdSec/XrdSecEntityAttr.hh>
 
+#include <atomic>
 #include <chrono>
 #include <condition_variable>
 #include <filesystem>

--- a/src/S3File.hh
+++ b/src/S3File.hh
@@ -147,6 +147,10 @@ class S3File : public XrdOssDF {
 	std::tuple<off_t, size_t, bool> DownloadBypass(off_t offset, size_t size,
 												   char *buffer);
 
+	// Invoked on the shutdown of the library, will trigger the background
+	// threads to wrap up and have a clean exit.
+	static void Shutdown() __attribute__((destructor));
+
 	XrdSysError &m_log;
 	S3FileSystem *m_oss;
 
@@ -322,4 +326,17 @@ class S3File : public XrdOssDF {
 		~S3Cache();
 	};
 	S3Cache m_cache{*this};
+
+	// Mutex for managing the shutdown of the background thread
+	static std::mutex m_shutdown_lock;
+	// Condition variable managing the requested shutdown of the background
+	// thread.
+	static std::condition_variable m_shutdown_requested_cv;
+	// Flag indicating that a shutdown was requested.
+	static bool m_shutdown_requested;
+	// Condition variable for the background thread to indicate it has
+	// completed.
+	static std::condition_variable m_shutdown_complete_cv;
+	// Flag indicating that the shutdown has completed.
+	static bool m_shutdown_complete;
 };

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -58,11 +58,13 @@ add_executable( s3-gtest s3_tests.cc )
 add_executable( s3-unit-test s3_unit_tests.cc )
 add_executable( http-gtest http_tests.cc )
 add_executable( filter-gtest filter_tests.cc ../src/shortfile.cc )
+add_executable( posc-gtest posc_tests.cc ../src/shortfile.cc )
 
 target_link_libraries(s3-gtest XrdS3Testing GTest::gtest_main Threads::Threads)
 target_link_libraries(s3-unit-test XrdS3Testing GTest::gtest_main Threads::Threads)
 target_link_libraries(http-gtest XrdHTTPServerTesting GTest::gtest_main Threads::Threads)
 target_link_libraries(filter-gtest XrdOssFilterTesting GTest::gtest_main Threads::Threads)
+target_link_libraries(posc-gtest XrdOssPoscTesting GTest::gtest_main Threads::Threads)
 
 gtest_add_tests(TARGET filter-gtest)
 
@@ -74,6 +76,8 @@ if (MINIO_BIN AND MC_BIN)
       ENVIRONMENT "ENV_FILE=${CMAKE_BINARY_DIR}/tests/s3_basic/setup.sh"
   )
 endif()
+
+gtest_add_tests(TARGET posc-gtest)
 
 add_test(
   NAME

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -78,7 +78,7 @@ if (MINIO_BIN AND MC_BIN)
   set_tests_properties(${s3UnitTests}
     PROPERTIES
       FIXTURES_REQUIRED S3::s3_basic
-      ENVIRONMENT "ENV_FILE=${CMAKE_BINARY_DIR}/tests/s3_basic/setup.sh"
+      ENVIRONMENT "ENV_FILE=${CMAKE_BINARY_DIR}/tests/s3_basic/setup.sh;LSAN_OPTIONS=suppressions=${CMAKE_CURRENT_SOURCE_DIR}/lsan-suppressions.txt"
   )
 endif()
 
@@ -131,7 +131,7 @@ add_test(NAME HTTP::basic::setup
 set_tests_properties(HTTP::basic::setup
   PROPERTIES
     FIXTURES_SETUP HTTP::basic
-    ENVIRONMENT "BINARY_DIR=${CMAKE_BINARY_DIR};SOURCE_DIR=${CMAKE_SOURCE_DIR};XROOTD_BINDIR=${XRootD_DATA_DIR}/../bin"
+    ENVIRONMENT "BINARY_DIR=${CMAKE_BINARY_DIR};SOURCE_DIR=${CMAKE_SOURCE_DIR};XROOTD_BINDIR=${XRootD_DATA_DIR}/../bin;LD_LIBRARY_PATH=${XRootD_LIB_DIR}"
 )
 
 add_test(NAME HTTP::basic::teardown
@@ -166,7 +166,7 @@ if (MINIO_BIN AND MC_BIN)
   set_tests_properties(S3::s3_basic::setup
     PROPERTIES
       FIXTURES_SETUP S3::s3_basic
-      ENVIRONMENT "BINARY_DIR=${CMAKE_BINARY_DIR};SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR};XROOTD_BINDIR=${XRootD_DATA_DIR}/../bin;MINIO_BIN=${MINIO_BIN};MC_BIN=${MC_BIN}"
+      ENVIRONMENT "BINARY_DIR=${CMAKE_BINARY_DIR};SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR};XROOTD_BINDIR=${XRootD_DATA_DIR}/../bin;LD_LIBRARY_PATH=${XRootD_LIB_DIR};MINIO_BIN=${MINIO_BIN};MC_BIN=${MC_BIN}"
   )
 
   add_test(NAME S3::s3_basic::teardown

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -66,7 +66,12 @@ target_link_libraries(http-gtest XrdHTTPServerTesting GTest::gtest_main Threads:
 target_link_libraries(filter-gtest XrdOssFilterTesting GTest::gtest_main Threads::Threads)
 target_link_libraries(posc-gtest XrdOssPoscTesting GTest::gtest_main Threads::Threads)
 
-gtest_add_tests(TARGET filter-gtest)
+gtest_add_tests(TARGET filter-gtest TEST_LIST filterUnitTests)
+
+set_tests_properties(${filterUnitTests}
+  PROPERTIES
+    ENVIRONMENT "LSAN_OPTIONS=suppressions=${CMAKE_CURRENT_SOURCE_DIR}/lsan-suppressions.txt"
+)
 
 if (MINIO_BIN AND MC_BIN)
   gtest_add_tests(TARGET s3-unit-test TEST_LIST s3UnitTests)
@@ -77,7 +82,12 @@ if (MINIO_BIN AND MC_BIN)
   )
 endif()
 
-gtest_add_tests(TARGET posc-gtest)
+gtest_add_tests(TARGET posc-gtest TEST_LIST poscUnitTests)
+
+set_tests_properties(${poscUnitTests}
+  PROPERTIES
+    ENVIRONMENT "LSAN_OPTIONS=suppressions=${CMAKE_CURRENT_SOURCE_DIR}/lsan-suppressions.txt"
+)
 
 add_test(
   NAME
@@ -85,12 +95,16 @@ add_test(
   COMMAND
     ${CMAKE_CURRENT_BINARY_DIR}/s3-gtest
 )
+set_tests_properties(s3-unit
+  PROPERTIES
+    ENVIRONMENT "LSAN_OPTIONS=suppressions=${CMAKE_CURRENT_SOURCE_DIR}/lsan-suppressions.txt"
+)
 
 gtest_add_tests(TARGET http-gtest TEST_LIST httpUnitTests)
 
 set_tests_properties( ${httpUnitTests}
   PROPERTIES
-    ENVIRONMENT "ENV_FILE=${CMAKE_CURRENT_BINARY_DIR}/../tests/basic/setup.sh"
+    ENVIRONMENT "ENV_FILE=${CMAKE_CURRENT_BINARY_DIR}/../tests/basic/setup.sh;LSAN_OPTIONS=suppressions=${CMAKE_CURRENT_SOURCE_DIR}/lsan-suppressions.txt"
     FIXTURES_REQUIRED HTTP::basic
 )
 
@@ -152,7 +166,7 @@ if (MINIO_BIN AND MC_BIN)
   set_tests_properties(S3::s3_basic::setup
     PROPERTIES
       FIXTURES_SETUP S3::s3_basic
-      ENVIRONMENT "BINARY_DIR=${CMAKE_BINARY_DIR};SOURCE_DIR=${CMAKE_SOURCE_DIR};XROOTD_BINDIR=${XRootD_DATA_DIR}/../bin;MINIO_BIN=${MINIO_BIN};MC_BIN=${MC_BIN}"
+      ENVIRONMENT "BINARY_DIR=${CMAKE_BINARY_DIR};SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR};XROOTD_BINDIR=${XRootD_DATA_DIR}/../bin;MINIO_BIN=${MINIO_BIN};MC_BIN=${MC_BIN}"
   )
 
   add_test(NAME S3::s3_basic::teardown

--- a/test/http_tests.cc
+++ b/test/http_tests.cc
@@ -82,9 +82,11 @@ TEST(TestHTTPFile, TestList) {
 	ASSERT_EQ(rc, 0);
 	ASSERT_EQ(si.st_size, 4096);
 
-	auto fd = fs.newDir();
-	struct stat *statStruct = new struct stat;
-	fd->StatRet(statStruct);
+	auto fd_raw = fs.newDir();
+	ASSERT_NE(fd_raw, nullptr);
+	std::unique_ptr<XrdOssDF> fd(fd_raw);
+	struct stat statStruct;
+	fd->StatRet(&statStruct);
 
 	rc = fd->Open("/testdir", O_RDONLY, 0700, env);
 	ASSERT_EQ(rc, -21);

--- a/test/lsan-suppressions.txt
+++ b/test/lsan-suppressions.txt
@@ -1,0 +1,1 @@
+leak:XrdOucGatherConf::XrdOucGatherConf

--- a/test/posc_tests.cc
+++ b/test/posc_tests.cc
@@ -100,13 +100,14 @@ TEST_F(TestPosc, BasicFileVisibility) {
 	ASSERT_NE(default_oss, nullptr) << "Failed to get Posc OSS instance";
 
 	std::unique_ptr<XrdSysError> log(new XrdSysError(&logger, "posc_"));
-	PoscFileSystem *posc_fs;
+	PoscFileSystem *posc_fs_raw;
 	try {
-		posc_fs = new PoscFileSystem(default_oss, std::move(log),
-									 GetConfigFile().c_str(), &env);
+		posc_fs_raw = new PoscFileSystem(default_oss, std::move(log),
+										 GetConfigFile().c_str(), &env);
 	} catch (const std::exception &e) {
 		FAIL() << "Failed to create PoscFileSystem: " << e.what();
 	}
+	std::unique_ptr<PoscFileSystem> posc_fs(posc_fs_raw);
 
 	std::unique_ptr<XrdOssDF> fp(posc_fs->newFile());
 	ASSERT_NE(fp, nullptr) << "Failed to create new file object";
@@ -163,14 +164,15 @@ TEST_F(TestPosc, BasicFilesystemVisibility) {
 	ASSERT_NE(default_oss, nullptr) << "Failed to get Posc OSS instance";
 
 	std::unique_ptr<XrdSysError> log(new XrdSysError(&logger, "posc_"));
-	PoscFileSystem *posc_fs;
+	PoscFileSystem *posc_fs_raw;
 	try {
-		posc_fs = new PoscFileSystem(default_oss, std::move(log),
-									 GetConfigFile().c_str(), &env);
+		posc_fs_raw = new PoscFileSystem(default_oss, std::move(log),
+										 GetConfigFile().c_str(), &env);
 	} catch (const std::exception &e) {
 		FAIL() << "Failed to create PoscFileSystem: " << e.what();
 	}
-	ASSERT_NE(posc_fs, nullptr) << "Failed to allocate filesystem object";
+	ASSERT_NE(posc_fs_raw, nullptr) << "Failed to allocate filesystem object";
+	std::unique_ptr<PoscFileSystem> posc_fs(posc_fs_raw);
 
 	// Should not be able to stat the POSC directory
 	struct stat buff;
@@ -188,7 +190,9 @@ TEST_F(TestPosc, BasicFilesystemVisibility) {
 		<< strerror(errno);
 
 	// Listing of the parent directory should not contain the POSC directory
-	auto dp = posc_fs->newDir();
+	auto dp_raw = posc_fs->newDir();
+	ASSERT_NE(dp_raw, nullptr);
+	std::unique_ptr<XrdOssDF> dp(dp_raw);
 	rv = dp->Opendir("/", env);
 	ASSERT_EQ(rv, 0) << "Failed to open root directory";
 	char fname[NAME_MAX];
@@ -211,13 +215,14 @@ TEST_F(TestPosc, TempfileUpdate) {
 	ASSERT_NE(default_oss, nullptr) << "Failed to get Posc OSS instance";
 
 	std::unique_ptr<XrdSysError> log(new XrdSysError(&logger, "posc_"));
-	PoscFileSystem *posc_fs;
+	PoscFileSystem *posc_fs_raw;
 	try {
-		posc_fs = new PoscFileSystem(default_oss, std::move(log),
-									 GetConfigFile().c_str(), &env);
+		posc_fs_raw = new PoscFileSystem(default_oss, std::move(log),
+										 GetConfigFile().c_str(), &env);
 	} catch (const std::exception &e) {
 		FAIL() << "Failed to create PoscFileSystem: " << e.what();
 	}
+	std::unique_ptr<PoscFileSystem> posc_fs(posc_fs_raw);
 
 	std::unique_ptr<XrdOssDF> fp(posc_fs->newFile());
 	ASSERT_NE(fp, nullptr) << "Failed to create new file object";

--- a/test/posc_tests.cc
+++ b/test/posc_tests.cc
@@ -27,6 +27,7 @@
 #include <gtest/gtest.h>
 
 #include <chrono>
+#include <fcntl.h>
 #include <string>
 #include <thread>
 

--- a/test/posc_tests.cc
+++ b/test/posc_tests.cc
@@ -1,0 +1,290 @@
+/***************************************************************
+ *
+ * Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+#include "../src/Posc.hh"
+#include "../src/shortfile.hh"
+
+#include <XrdOss/XrdOssDefaultSS.hh>
+#include <XrdOuc/XrdOucEnv.hh>
+#include <XrdSys/XrdSysLogger.hh>
+#include <XrdVersion.hh>
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <string>
+#include <thread>
+
+class TestPosc : public testing::Test {
+  protected:
+	virtual std::string GetConfig() {
+		std::stringstream ss;
+		ss << "oss.localroot " << m_temp_dir << "\n";
+		ss << "posc.prefix "
+		   << "/posc_test\n"
+			  "posc.trace debug\n";
+		return ss.str();
+	}
+
+	void SetUp() override {
+		setenv("XRDINSTANCE", "xrootd", 1);
+		char tmp_configfn[] = "/tmp/xrootd-gtest.cfg.XXXXXX";
+		auto result = mkstemp(tmp_configfn);
+		ASSERT_NE(result, -1) << "Failed to create temp file ("
+							  << strerror(errno) << ", errno=" << errno << ")";
+		m_configfn = std::string(tmp_configfn);
+
+		auto temp_dir = std::filesystem::temp_directory_path() /
+						"gtest_temp_xrootd_localroot"; // Generate a unique name
+		std::error_code ec;
+		if (!std::filesystem::create_directory(temp_dir, ec)) {
+			ASSERT_FALSE(ec)
+				<< "Failed to create temp directory: " << ec.message();
+		}
+		m_temp_dir = temp_dir.string();
+
+		auto contents = GetConfig();
+		ASSERT_FALSE(contents.empty());
+		ASSERT_TRUE(writeShortFile(m_configfn, contents, 0))
+			<< "Failed to write to temp file (" << strerror(errno)
+			<< ", errno=" << errno << ")";
+	}
+
+	void TearDown() override {
+		if (!m_configfn.empty()) {
+			auto rv = unlink(m_configfn.c_str());
+			ASSERT_EQ(rv, 0) << "Failed to delete temp file ("
+							 << strerror(errno) << ", errno=" << errno << ")";
+		}
+		if (!m_temp_dir.empty()) {
+			std::error_code ec;
+			auto rv = std::filesystem::remove_all(m_temp_dir, ec);
+			ASSERT_NE(rv, -1)
+				<< "Failed to delete temp directory (" << ec.message()
+				<< ", errno=" << ec.value() << ")";
+		}
+	}
+
+	std::string GetConfigFile() const { return m_configfn; }
+
+  private:
+	std::string m_temp_dir;
+	std::string m_configfn;
+};
+
+TEST_F(TestPosc, BasicFileVisibility) {
+	XrdSysLogger logger(2, 0);
+	XrdOucEnv env;
+
+	XrdVERSIONINFODEF(XrdOssDefault, Oss, XrdVNUMBER, XrdVERSION);
+
+	XrdOss *default_oss =
+		XrdOssDefaultSS(&logger, GetConfigFile().c_str(), XrdOssDefault);
+
+	ASSERT_NE(default_oss, nullptr) << "Failed to get Posc OSS instance";
+
+	std::unique_ptr<XrdSysError> log(new XrdSysError(&logger, "posc_"));
+	PoscFileSystem *posc_fs;
+	try {
+		posc_fs = new PoscFileSystem(default_oss, std::move(log),
+									 GetConfigFile().c_str(), &env);
+	} catch (const std::exception &e) {
+		FAIL() << "Failed to create PoscFileSystem: " << e.what();
+	}
+
+	std::unique_ptr<XrdOssDF> fp(posc_fs->newFile());
+	ASSERT_NE(fp, nullptr) << "Failed to create new file object";
+
+	fp->Open("/testfile.txt", O_CREAT | O_RDWR, 0644, env);
+
+	auto rv = posc_fs->Stat("/testfile.txt", nullptr, 0, &env);
+	ASSERT_NE(rv, 0) << "Temporary file is visible";
+	ASSERT_EQ(rv, -ENOENT)
+		<< "Stat on not-visible file should have resulted in ENOENT: "
+		<< strerror(-rv);
+
+	ASSERT_EQ(fp->Close(), 0) << "Failed to close file";
+
+	struct stat sb;
+	rv = posc_fs->Stat("/testfile.txt", &sb, 0, &env);
+
+	ASSERT_EQ(rv, 0) << "Stat on created file failed: " << strerror(-rv);
+	ASSERT_TRUE(S_ISREG(sb.st_mode))
+		<< "Stat on created file did not return regular file";
+	ASSERT_EQ(sb.st_size, 0) << "Stat on created file did not return size 0";
+
+	fp->Open("/testfile2.txt", O_CREAT | O_RDWR, 0644, env);
+	auto write_size = strlen("Hello, POSC!");
+	ASSERT_EQ(fp->Write("Hello, POSC!", 0, write_size), write_size);
+
+	rv = posc_fs->Stat("/testfile2.txt", nullptr, 0, &env);
+	ASSERT_NE(rv, 0) << "Temporary file is visible";
+	ASSERT_EQ(rv, -ENOENT)
+		<< "Stat on not-visible file should have resulted in ENOENT: "
+		<< strerror(-rv);
+
+	ASSERT_EQ(fp->Close(), 0) << "Failed to close file";
+
+	memset(&sb, '\0', sizeof(sb));
+	rv = posc_fs->Stat("/testfile2.txt", &sb, 0, &env);
+
+	ASSERT_EQ(rv, 0) << "Stat on created file failed: " << strerror(-rv);
+	ASSERT_TRUE(S_ISREG(sb.st_mode))
+		<< "Stat on created file did not return regular file";
+	ASSERT_EQ(sb.st_size, write_size)
+		<< "Stat on created file did not return size " << write_size;
+}
+
+TEST_F(TestPosc, BasicFilesystemVisibility) {
+	XrdSysLogger logger(2, 0);
+	XrdOucEnv env;
+
+	XrdVERSIONINFODEF(XrdOssDefault, Oss, XrdVNUMBER, XrdVERSION);
+
+	XrdOss *default_oss =
+		XrdOssDefaultSS(&logger, GetConfigFile().c_str(), XrdOssDefault);
+
+	ASSERT_NE(default_oss, nullptr) << "Failed to get Posc OSS instance";
+
+	std::unique_ptr<XrdSysError> log(new XrdSysError(&logger, "posc_"));
+	PoscFileSystem *posc_fs;
+	try {
+		posc_fs = new PoscFileSystem(default_oss, std::move(log),
+									 GetConfigFile().c_str(), &env);
+	} catch (const std::exception &e) {
+		FAIL() << "Failed to create PoscFileSystem: " << e.what();
+	}
+	ASSERT_NE(posc_fs, nullptr) << "Failed to allocate filesystem object";
+
+	// Should not be able to stat the POSC directory
+	struct stat buff;
+	auto rv = posc_fs->Stat("/posc_test", &buff);
+	ASSERT_NE(rv, 0) << "Expected stat of hidden directory to fail";
+	ASSERT_EQ(rv, -ENOENT)
+		<< "Expected stat of hidden directory to fail with ENOENT; got "
+		<< strerror(errno);
+
+	// Should not be able to create the POSC directory
+	rv = posc_fs->Mkdir("/posc_test/foo", 0755, 1, &env);
+	ASSERT_NE(rv, 0) << "Expected mkdir inside POSC dir to fail";
+	ASSERT_EQ(rv, -EIO)
+		<< "Expected mkdir inside POSC dir to result in an EIO.  Got "
+		<< strerror(errno);
+
+	// Listing of the parent directory should not contain the POSC directory
+	auto dp = posc_fs->newDir();
+	rv = dp->Opendir("/", env);
+	ASSERT_EQ(rv, 0) << "Failed to open root directory";
+	char fname[NAME_MAX];
+	while (((rv = dp->Readdir(fname, NAME_MAX)) == 0) && (fname[0] != '\0')) {
+		fprintf(stderr, "File component: %s\n", fname);
+	}
+	ASSERT_EQ(rv, 0) << "Failed to list directory: " << strerror(-rv);
+	ASSERT_EQ(dp->Close(), 0) << "Failed to close root directory";
+}
+
+TEST_F(TestPosc, TempfileUpdate) {
+	XrdSysLogger logger(2, 0);
+	XrdOucEnv env;
+
+	XrdVERSIONINFODEF(XrdOssDefault, Oss, XrdVNUMBER, XrdVERSION);
+
+	XrdOss *default_oss =
+		XrdOssDefaultSS(&logger, GetConfigFile().c_str(), XrdOssDefault);
+
+	ASSERT_NE(default_oss, nullptr) << "Failed to get Posc OSS instance";
+
+	std::unique_ptr<XrdSysError> log(new XrdSysError(&logger, "posc_"));
+	PoscFileSystem *posc_fs;
+	try {
+		posc_fs = new PoscFileSystem(default_oss, std::move(log),
+									 GetConfigFile().c_str(), &env);
+	} catch (const std::exception &e) {
+		FAIL() << "Failed to create PoscFileSystem: " << e.what();
+	}
+
+	std::unique_ptr<XrdOssDF> fp(posc_fs->newFile());
+	ASSERT_NE(fp, nullptr) << "Failed to create new file object";
+
+	fp->Open("/testfile.txt", O_CREAT | O_RDWR, 0644, env);
+
+	auto pfp = dynamic_cast<PoscFile *>(fp.get());
+	ASSERT_NE(fp, nullptr)
+		<< "Returned file pointer should be of type PoscFile";
+
+	auto posc_filename = pfp->GetPoscFilename();
+	ASSERT_FALSE(posc_filename.empty())
+		<< "POSC file is not opened in POSC mode";
+
+	struct stat buff;
+	auto rv = default_oss->Stat(posc_filename.c_str(), &buff, 0, &env);
+	ASSERT_EQ(rv, 0) << "Failed to stat underlying POSC file";
+
+#ifdef __APPLE__
+	struct timespec now = buff.st_mtimespec;
+#else
+	struct timespec now = buff.st_mtim;
+#endif
+
+	auto now_chrono = std::chrono::time_point<std::chrono::system_clock,
+											  std::chrono::nanoseconds>(
+		std::chrono::seconds(now.tv_sec) +
+		std::chrono::nanoseconds(now.tv_nsec));
+
+	PoscFile::SetFileUpdateDuration(std::chrono::nanoseconds(100));
+
+	std::this_thread::sleep_for(std::chrono::milliseconds(1));
+
+	PoscFile::UpdateOpenFiles();
+
+	memset(&buff, '\0', sizeof(buff));
+	rv = default_oss->Stat(posc_filename.c_str(), &buff, 0, &env);
+	ASSERT_EQ(rv, 0) << "Failed to stat underlying POSC file";
+
+#ifdef __APPLE__
+	now = buff.st_mtimespec;
+#else
+	now = buff.st_mtim;
+#endif
+
+	auto update_chrono = std::chrono::time_point<std::chrono::system_clock,
+												 std::chrono::nanoseconds>(
+		std::chrono::seconds(now.tv_sec) +
+		std::chrono::nanoseconds(now.tv_nsec));
+
+	ASSERT_TRUE(update_chrono > now_chrono)
+		<< "POSC file mtime was not updated after UpdateOpenFiles call";
+
+	// Try expiring the user files - shouldn't do anything as the default
+	// timeout is quite large.
+	posc_fs->ExpireFiles();
+
+	rv = default_oss->Stat(posc_filename.c_str(), &buff, 0, &env);
+	ASSERT_EQ(rv, 0) << "Failed to stat underlying POSC file";
+
+	// Decrease the file expiration time, sleep, and then expire again.
+	PoscFileSystem::SetFileTimeout(std::chrono::nanoseconds(100));
+	std::this_thread::sleep_for(std::chrono::milliseconds(1));
+
+	posc_fs->ExpireFiles();
+
+	rv = default_oss->Stat(posc_filename.c_str(), &buff, 0, &env);
+	ASSERT_NE(rv, 0) << "Expire failed to delete underlying user file";
+	ASSERT_EQ(rv, -ENOENT) << "Unexpected error when stating POSC file: "
+						   << strerror(errno);
+}

--- a/test/s3-setup.sh
+++ b/test/s3-setup.sh
@@ -294,7 +294,7 @@ export X509_CERT_FILE=$MINIO_CERTSDIR/CAs/tlsca.pem
 if [ "$VALGRIND" -eq 1 ]; then
   valgrind --leak-check=full --track-origins=yes "$XROOTD_BIN" -c "$XROOTD_CONFIG" -l "$BINARY_DIR/tests/$TEST_NAME/server.log" 0<&- 2>>"$BINARY_DIR/tests/$TEST_NAME/server.log" >>"$BINARY_DIR/tests/$TEST_NAME/server.log" &
 else
-  "$XROOTD_BIN" -c "$XROOTD_CONFIG" -l "$BINARY_DIR/tests/$TEST_NAME/server.log" 0<&- 2>>"$BINARY_DIR/tests/$TEST_NAME/server.log" >>"$BINARY_DIR/tests/$TEST_NAME/server.log" &
+  LSAN_OPTIONS=suppressions=${SOURCE_DIR}/lsan-suppressions.txt "$XROOTD_BIN" -c "$XROOTD_CONFIG" -l "$BINARY_DIR/tests/$TEST_NAME/server.log" 0<&- 2>>"$BINARY_DIR/tests/$TEST_NAME/server.log" >>"$BINARY_DIR/tests/$TEST_NAME/server.log" &
 fi
 XROOTD_PID=$!
 echo "xrootd daemon PID: $XROOTD_PID"
@@ -307,6 +307,8 @@ while [ -z "$XROOTD_URL" ]; do
   IDX=$(($IDX+1))
   if ! kill -0 "$XROOTD_PID" 2>/dev/null; then
     echo "xrootd process (PID $XROOTD_PID) failed to start" >&2
+    echo "Echoing server logs" >&2
+    cat "$BINARY_DIR/tests/$TEST_NAME/server.log" >&2
     exit 1
   fi
   if [ $IDX -gt 1 ]; then

--- a/test/s3-setup.sh
+++ b/test/s3-setup.sh
@@ -294,7 +294,7 @@ export X509_CERT_FILE=$MINIO_CERTSDIR/CAs/tlsca.pem
 if [ "$VALGRIND" -eq 1 ]; then
   valgrind --leak-check=full --track-origins=yes "$XROOTD_BIN" -c "$XROOTD_CONFIG" -l "$BINARY_DIR/tests/$TEST_NAME/server.log" 0<&- 2>>"$BINARY_DIR/tests/$TEST_NAME/server.log" >>"$BINARY_DIR/tests/$TEST_NAME/server.log" &
 else
-  LSAN_OPTIONS=suppressions=${SOURCE_DIR}/lsan-suppressions.txt "$XROOTD_BIN" -c "$XROOTD_CONFIG" -l "$BINARY_DIR/tests/$TEST_NAME/server.log" 0<&- 2>>"$BINARY_DIR/tests/$TEST_NAME/server.log" >>"$BINARY_DIR/tests/$TEST_NAME/server.log" &
+  ASAN_OPTIONS=detect_odr_violation=0 LSAN_OPTIONS=suppressions=${SOURCE_DIR}/lsan-suppressions.txt "$XROOTD_BIN" -c "$XROOTD_CONFIG" -l "$BINARY_DIR/tests/$TEST_NAME/server.log" 0<&- 2>>"$BINARY_DIR/tests/$TEST_NAME/server.log" >>"$BINARY_DIR/tests/$TEST_NAME/server.log" &
 fi
 XROOTD_PID=$!
 echo "xrootd daemon PID: $XROOTD_PID"

--- a/test/xrdhttp-setup.sh
+++ b/test/xrdhttp-setup.sh
@@ -171,7 +171,7 @@ mkdir "$XROOTD_EXPORTDIR/testdir"
 echo "Hello, World" > "$XROOTD_EXPORTDIR/testdir/hello_world.txt"
 
 # Launch XRootD daemon.
-"$XROOTD_BIN" -c "$XROOTD_CONFIG" -l "$BINARY_DIR/tests/$TEST_NAME/server.log" 0<&- >>"$BINARY_DIR/tests/$TEST_NAME/server.log" 2>>"$BINARY_DIR/tests/$TEST_NAME/server.log" &
+ASAN_OPTIONS=detect_odr_violation=0 "$XROOTD_BIN" -c "$XROOTD_CONFIG" -l "$BINARY_DIR/tests/$TEST_NAME/server.log" 0<&- >>"$BINARY_DIR/tests/$TEST_NAME/server.log" 2>>"$BINARY_DIR/tests/$TEST_NAME/server.log" &
 XROOTD_PID=$!
 echo "xrootd daemon PID: $XROOTD_PID"
 


### PR DESCRIPTION
This plugin makes it so any files being uploaded are not visible in the namespace until they have been successfully closed by the client.  Files that are partially uploaded by the client -- or were being uploaded when the server crashed -- will eventually be deleted.

This would prevent files from being accidentally read & cached prior to being completed.