### PR TITLE
Add guard against setting m_b.off too high

### DIFF
--- a/src/S3File.cc
+++ b/src/S3File.cc
@@ -911,11 +911,12 @@ ssize_t S3File::S3Cache::Read(char *buffer, off_t offset, size_t size) {
 					download_a = true;
 					next_offset += m_cache_entry_size;
 				}
-			if (next_offset < m_parent.content_length) {
-				if (!m_b.m_inprogress && m_b.m_used >= m_cache_entry_size) {
-					m_b.m_inprogress = true;
-					m_b.m_off = next_offset;
-					download_b = true;
+				if (next_offset < m_parent.content_length) {
+					if (!m_b.m_inprogress && m_b.m_used >= m_cache_entry_size) {
+						m_b.m_inprogress = true;
+						m_b.m_off = next_offset;
+						download_b = true;
+					}
 				}
 			}
 		}

--- a/src/S3File.cc
+++ b/src/S3File.cc
@@ -687,12 +687,12 @@ OverlapCopy(off_t req_off, size_t req_size, char *req_buf, off_t cache_off,
 			auto cache_buf_off = static_cast<size_t>(req_off - cache_off);
 			auto cache_copy_bytes =
 				std::min(static_cast<size_t>(cache_end - req_off), req_size);
-
+			
 			// DEBUG: Print values before memcpy
 			std::cout << "DEBUG memcpy: cache_buf_off=" << cache_buf_off 
 					  << ", cache_copy_bytes=" << cache_copy_bytes 
 					  << ", cache_size=" << cache_size << std::endl;
-
+			
 			memcpy(req_buf, cache_buf + cache_buf_off, cache_copy_bytes);
 			used += cache_copy_bytes;
 			return std::make_tuple(req_off + cache_copy_bytes,
@@ -729,7 +729,7 @@ S3File::S3Cache::Entry::OverlapCopy(off_t req_off, size_t req_size,
 			  << ", m_off=" << m_off << ", m_cache_entry_size=" << m_cache_entry_size 
 			  << ", m_data.size()=" << m_data.size() << std::endl;
 
-	auto results =a
+	auto results =
 		::OverlapCopy(req_off, req_size, req_buf, m_off, m_cache_entry_size,
 					  m_data.data(), bytes_copied);
 	if (is_hit) {

--- a/src/S3File.cc
+++ b/src/S3File.cc
@@ -687,6 +687,12 @@ OverlapCopy(off_t req_off, size_t req_size, char *req_buf, off_t cache_off,
 			auto cache_buf_off = static_cast<size_t>(req_off - cache_off);
 			auto cache_copy_bytes =
 				std::min(static_cast<size_t>(cache_end - req_off), req_size);
+
+			// DEBUG: Print values before memcpy
+			std::cout << "DEBUG memcpy: cache_buf_off=" << cache_buf_off 
+					  << ", cache_copy_bytes=" << cache_copy_bytes 
+					  << ", cache_size=" << cache_size << std::endl;
+
 			memcpy(req_buf, cache_buf + cache_buf_off, cache_copy_bytes);
 			used += cache_copy_bytes;
 			return std::make_tuple(req_off + cache_copy_bytes,
@@ -717,7 +723,13 @@ std::tuple<off_t, size_t, off_t, size_t>
 S3File::S3Cache::Entry::OverlapCopy(off_t req_off, size_t req_size,
 									char *req_buf, bool is_hit) {
 	size_t bytes_copied = 0;
-	auto results =
+
+	// DEBUG: Print cache state before OverlapCopy
+	std::cout << "DEBUG OverlapCopy: req_off=" << req_off << ", req_size=" << req_size 
+			  << ", m_off=" << m_off << ", m_cache_entry_size=" << m_cache_entry_size 
+			  << ", m_data.size()=" << m_data.size() << std::endl;
+
+	auto results =a
 		::OverlapCopy(req_off, req_size, req_buf, m_off, m_cache_entry_size,
 					  m_data.data(), bytes_copied);
 	if (is_hit) {

--- a/src/S3File.cc
+++ b/src/S3File.cc
@@ -911,6 +911,7 @@ ssize_t S3File::S3Cache::Read(char *buffer, off_t offset, size_t size) {
 					download_a = true;
 					next_offset += m_cache_entry_size;
 				}
+			if (next_offset < m_parent.content_length) {
 				if (!m_b.m_inprogress && m_b.m_used >= m_cache_entry_size) {
 					m_b.m_inprogress = true;
 					m_b.m_off = next_offset;

--- a/test/s3_unit_tests.cc
+++ b/test/s3_unit_tests.cc
@@ -639,7 +639,7 @@ TEST_F(FileSystemS3Fixture, S3CachePrefetchBoundsBug) {
 	// - next_offset = max(0, cache_entry_size) + cache_entry_size = 2 * cache_entry_size
 	// - Initial check: if (2 * cache_entry_size < content_length) - should PASS
 	// - After cache A prefetch: next_offset = 2 * cache_entry_size + cache_entry_size = 3 * cache_entry_size  
-	// - Cache B prefetch: m_b.m_off = 3 * cache_entry_size - BUG: exceeds content_length!
+	// - Cache B prefetch: m_b.m_off = 3 * cache_entry_size
 	const size_t cache_entry_size = 2'097'152; // 2MB cache entry (default)
 	const off_t file_size = 2 * cache_entry_size + cache_entry_size / 2; // 5MB file
 


### PR DESCRIPTION
Adds a guard against m_b.off > m_parent.content_length

Adds a test which should demonstrate the error that can occur without the guard.
