### PR TITLE
Added missing check for next_offset < m_parent.content_length

### DIFF
--- a/src/S3File.cc
+++ b/src/S3File.cc
@@ -911,10 +911,12 @@ ssize_t S3File::S3Cache::Read(char *buffer, off_t offset, size_t size) {
 					download_a = true;
 					next_offset += m_cache_entry_size;
 				}
-				if (!m_b.m_inprogress && m_b.m_used >= m_cache_entry_size) {
-					m_b.m_inprogress = true;
-					m_b.m_off = next_offset;
-					download_b = true;
+				if (next_offset < m_parent.content_length) {
+					if (!m_b.m_inprogress && m_b.m_used >= m_cache_entry_size) {
+						m_b.m_inprogress = true;
+						m_b.m_off = next_offset;
+						download_b = true;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Adds a missing guard for an offset value for m_b.off.

A regression test for this cannot be created because the specific circumstances and load under which this occurs is almost impossible to create artificially.

This should close #113 