### PR TITLE
POSC: Atomic directory and file visibility on upload

### DIFF
--- a/src/Posc.hh
+++ b/src/Posc.hh
@@ -211,8 +211,6 @@ class PoscFile final : public XrdOssWrapDF {
 	std::atomic<std::chrono::system_clock::duration::rep> m_posc_mtime{0};
 	std::string m_posc_filename;
 	std::string m_orig_filename;
-	std::string m_parent_to_create; // Parent directory to create on close
-									// (empty if exists)
 	off_t m_expected_size{
 		-1}; // Expected file size from oss.asize, -1 if unknown
 


### PR DESCRIPTION
This PR changes POSC semantics so that parent directories and files appear atomically after a successful upload, and fixes a crash when processing requests with unmapped usernames. This test also updates a test to reflect this behavior and verify the semantics.

This PR also fixes null-pointer dereference `ExpireUserFiles()` when `secEnv()->name` is null.