### PR TITLE
Update spec for v0.6.3

### DIFF
--- a/rpm/xrootd-s3-http.spec
+++ b/rpm/xrootd-s3-http.spec
@@ -1,5 +1,5 @@
 Name:		xrootd-s3-http
-Version:        0.6.1
+Version:        0.6.3
 Release:        1%{?dist}
 Summary:        S3/HTTP/Globus filesystem plugins for xrootd
 
@@ -54,6 +54,11 @@ rm %{buildroot}%{_libdir}/libXrdPelicanHttpCore.so
 %license LICENSE
 
 %changelog
+* Mon Jan 26 2026 Patrick Brophy <patrick.brophy2@gmail.com> - 0.6.3-1
+- Fixed crash when copying XrdSecEntity in POSC plugin
+- Fixed parallel runs of POSC tests
+- Fixed definition of libXrdPelicanHttpCore
+
 * Wed Jan 14 2026 Patrick Brophy <patrick.brophy2@gmail.com> - 0.6.1-1
 - POSC plugin now creates parent directory when missing
 

--- a/src/CurlUtil.cc
+++ b/src/CurlUtil.cc
@@ -58,7 +58,7 @@ CURL *HandlerQueue::GetHandle() {
 		return result;
 	}
 
-	curl_easy_setopt(result, CURLOPT_USERAGENT, "xrootd-s3/0.6.1");
+	curl_easy_setopt(result, CURLOPT_USERAGENT, "xrootd-s3/0.6.3");
 	curl_easy_setopt(result, CURLOPT_BUFFERSIZE, 32 * 1024);
 	curl_easy_setopt(result, CURLOPT_NOSIGNAL, 1L);
 


### PR DESCRIPTION
I had accidentally forgot to update the spec file for v0.6.2 so I am going to make a new release for v0.6.3. Here is the updated spec file that should have been included in the v0.6.2 release.