### PR TITLE
Preserve return code of rename and return it to Close() caller

### DIFF
--- a/src/Posc.cc
+++ b/src/Posc.cc
@@ -775,8 +775,9 @@ int PoscFile::Close(long long *retsz) {
 
 		m_oss.Unlink(m_posc_filename.c_str(), 0, m_posc_env.get());
 		m_posc_filename.clear();
-		// Preserve the actual error (e.g. EISDIR when destination is a directory)
-		// so XRootD can map it to the correct HTTP status (e.g. 409 Conflict).
+		// Preserve the actual error (e.g. EISDIR when destination is a
+		// directory) so XRootD can map it to the correct HTTP status (e.g. 409
+		// Conflict).
 		return rv;
 	}
 	m_posc_filename.clear();


### PR DESCRIPTION
In order to match the behavior what HTTP status code Pelican [expects](https://github.com/PelicanPlatform/pelican/blob/d046781720e6e5e3f38b2927e739b50c7d2b2803/client/fed_long_test.go#L706) for conflicts during a sync upload we need to preserve the return code of call to`rename()` if there is a failure.