### PR TITLE
Support multiple exports in Globus XRootD plugin

### DIFF
--- a/src/GlobusDirectory.cc
+++ b/src/GlobusDirectory.cc
@@ -49,19 +49,20 @@ void GlobusDirectory::Reset() {
 	m_directories.clear();
 	m_stat_buf = nullptr;
 	m_object = "";
+	m_route = nullptr;
 }
 
 int GlobusDirectory::ListGlobusDir() {
 	m_log.Log(XrdHTTPServer::Debug, "GlobusDirectory::ListGlobusDir",
 			  "Listing directory:", m_object.c_str());
 
-	auto token = m_fs.getTransferToken();
-	if (!token) {
+	if (!m_route || !m_route->transfer_token) {
 		m_log.Emsg("Listing", "Failed to get transfer token");
 		return -ENOENT;
 	}
+	auto token = m_route->transfer_token.get();
 
-	HTTPDownload listCommand(m_fs.getLsUrl(), m_object, m_log, token);
+	HTTPDownload listCommand(m_fs.getLsUrl(*m_route), m_object, m_log, token);
 	if (!listCommand.SendRequest(0, 0)) {
 		return HTTPRequest::HandleHTTPError(
 			listCommand, m_log, "Globus directory listing", m_object.c_str());
@@ -122,20 +123,16 @@ int GlobusDirectory::Opendir(const char *path, XrdOucEnv &env) {
 		realPath = realPath + "/";
 	}
 
-	std::string storagePrefix = m_fs.getStoragePrefix();
-	std::string object;
-
-	if (realPath.find(storagePrefix) == 0) {
-		object = realPath.substr(storagePrefix.length());
-	} else {
-		object = realPath;
+	std::string relative_path;
+	int rv = m_fs.ResolvePath(realPath, m_route, relative_path);
+	if (rv != 0) {
+		return rv;
+	}
+	if (!relative_path.empty() && relative_path[0] == '/') {
+		relative_path = relative_path.substr(1);
 	}
 
-	if (!object.empty() && object[0] == '/') {
-		object = object.substr(1);
-	}
-
-	m_object = object;
+	m_object = relative_path;
 
 	return ListGlobusDir();
 }

--- a/src/GlobusDirectory.hh
+++ b/src/GlobusDirectory.hh
@@ -57,9 +57,9 @@ class GlobusDirectory : public XrdOssDF {
 	ssize_t m_idx{0};
 	std::vector<GlobusObjectInfo> m_objInfo;
 	std::vector<GlobusObjectInfo> m_directories;
-	std::string m_prefix;
 	std::string m_object;
 	XrdSysError &m_log;
 	const GlobusFileSystem &m_fs;
+	const GlobusFileSystem::GlobusRouteConfig *m_route{nullptr};
 	struct stat *m_stat_buf{nullptr};
 };

--- a/src/GlobusFileSystem.cc
+++ b/src/GlobusFileSystem.cc
@@ -65,8 +65,7 @@ class GlobusMkdirRequest final : public HTTPRequest {
 
 GlobusFileSystem::GlobusFileSystem(XrdOss *oss, XrdSysLogger *lp,
 								   const char *configfn, XrdOucEnv *envP)
-	: XrdOssWrapper(*oss), m_oss(oss), m_log(lp, "globus_"),
-	  m_transfer_token("", nullptr) {
+	: XrdOssWrapper(*oss), m_oss(oss), m_log(lp, "globus_") {
 	m_log.Say("------ Initializing the Globus filesystem plugin.");
 
 	if (!Config(lp, configfn)) {
@@ -111,18 +110,47 @@ bool GlobusFileSystem::Config(XrdSysLogger *lp, const char *configfn) {
 		return false;
 	}
 
-	std::string attribute;
-	std::string transfer_token_file;
-	std::string endpoint_path;
+	bool saw_blocks = false;
+	bool in_block = false;
+	GlobusRouteConfig default_route;
+	std::shared_ptr<GlobusRouteConfig> route(new GlobusRouteConfig(default_route));
 
 	m_log.setMsgMask(0);
 
 	while (globus_conf.GetLine()) {
-		attribute = globus_conf.GetToken();
+		std::string attribute = globus_conf.GetToken();
 		if (!strcmp(attribute.c_str(), "globus.trace")) {
 			if (!XrdHTTPServer::ConfigLog(globus_conf, m_log)) {
 				m_log.Emsg("Config", "Failed to configure the log level");
 			}
+			continue;
+		}
+
+		if (!strcmp(attribute.c_str(), "globus.begin")) {
+			if (in_block) {
+				m_log.Emsg("Config", "Nested globus.begin blocks are not allowed");
+				return false;
+			}
+			in_block = true;
+			saw_blocks = true;
+			route.reset(new GlobusRouteConfig(default_route));
+			continue;
+		}
+		if (!strcmp(attribute.c_str(), "globus.end")) {
+			if (!in_block) {
+				m_log.Emsg("Config", "Encountered globus.end without matching begin");
+				return false;
+			}
+			if (route->storage_prefix.empty() || route->endpoint_path.empty() ||
+				route->transfer_url.empty()) {
+				m_log.Emsg("Config", "globus route is missing one or more required settings");
+				return false;
+			}
+			if (route->storage_prefix[0] != '/') {
+				route->storage_prefix = "/" + route->storage_prefix;
+			}
+			m_routes[route->storage_prefix] = route;
+			in_block = false;
 			continue;
 		}
 
@@ -131,39 +159,72 @@ bool GlobusFileSystem::Config(XrdSysLogger *lp, const char *configfn) {
 			continue;
 		}
 
+		auto &target = in_block ? *route : default_route;
+
 		if (!handle_required_config(attribute, "globus.endpoint_path", value,
-									endpoint_path) ||
+									target.endpoint_path) ||
 			!handle_required_config(attribute, "globus.storage_prefix", value,
-									m_storage_prefix) ||
+									target.storage_prefix) ||
 			!handle_required_config(attribute, "globus.transfer_url_base",
-									value, m_transfer_url) ||
-			!handle_required_config(attribute, "globus.transfer_token_file",
-									value, transfer_token_file)) {
+									value, target.transfer_url)) {
 			return false;
 		}
-	}
-
-	// Build the complete URLs
-	m_endpoint_path = endpoint_path;
-	if (!m_transfer_url.empty() && !endpoint_path.empty()) {
-		// Strip the trailing slash from endpoint_path before embedding it in
-		// the URL template.  extractRelativePath() always returns a path that
-		// starts with '/', so concatenating a trailing slash here would produce
-		// a double-slash (e.g. "?path=//top_level_path/custom_path").  Globus interprets
-		// "?path=//" as the root path and returns a 200 instead of a 404,
-		// causing parent-directory existence checks to spuriously succeed.
-		std::string ep = endpoint_path;
-		if (!ep.empty() && ep.back() == '/') {
-			ep.pop_back();
+		if (!strcmp(attribute.c_str(), "globus.transfer_token_file")) {
+			target.transfer_token = std::make_shared<TokenFile>(value, &m_log);
 		}
-		m_transfer_url += "/%s?path=" + ep;
 	}
 
-	if (!transfer_token_file.empty()) {
-		m_transfer_token = TokenFile(transfer_token_file, &m_log);
+	if (in_block) {
+		m_log.Emsg("Config", "Encountered unterminated globus.begin block");
+		return false;
+	}
+
+	if (!saw_blocks) {
+		auto final_route = std::make_shared<GlobusRouteConfig>(default_route);
+		if (final_route->storage_prefix.empty() || final_route->endpoint_path.empty() ||
+			final_route->transfer_url.empty()) {
+			m_log.Emsg("Config", "globus route is missing one or more required settings");
+			return false;
+		}
+		if (final_route->storage_prefix[0] != '/') {
+			final_route->storage_prefix = "/" + final_route->storage_prefix;
+		}
+		m_routes[final_route->storage_prefix] = final_route;
 	}
 
 	return true;
+}
+
+int GlobusFileSystem::ResolvePath(const std::string &path,
+								  const GlobusRouteConfig *&route,
+								  std::string &relative_path) const {
+	const GlobusRouteConfig *best_route = nullptr;
+	std::string best_object;
+	size_t best_len = 0;
+	for (const auto &entry : m_routes) {
+		std::string candidate_object;
+		if (parse_path(entry.second->storage_prefix, path.c_str(),
+					   candidate_object) != 0) {
+			continue;
+		}
+		size_t candidate_len = entry.second->storage_prefix.size();
+		if (!best_route || candidate_len > best_len) {
+			best_route = entry.second.get();
+			best_object = candidate_object;
+			best_len = candidate_len;
+		}
+	}
+	if (!best_route) {
+		return -ENOENT;
+	}
+	route = best_route;
+	relative_path = best_object;
+	if (relative_path.empty()) {
+		relative_path = "/";
+	} else if (relative_path[0] != '/') {
+		relative_path = "/" + relative_path;
+	}
+	return 0;
 }
 
 XrdOssDF *GlobusFileSystem::newDir(const char *user) {
@@ -177,19 +238,23 @@ XrdOssDF *GlobusFileSystem::newFile(const char *user) {
 
 int GlobusFileSystem::Stat(const char *path, struct stat *buff, int opts,
 						   XrdOucEnv *env) {
-	// Extract the part of path that comes after the storage prefix
-	std::string relative_path = extractRelativePath(path);
+	const GlobusRouteConfig *route = nullptr;
+	std::string relative_path;
+	int rv = ResolvePath(path, route, relative_path);
+	if (rv != 0) {
+		return rv;
+	}
 
 	m_log.Log(LogMask::Debug, "GlobusFileSystem::Stat", "Stat'ing path",
 			  relative_path.c_str());
 
-	auto token = getTransferToken();
+	auto token = route->transfer_token.get();
 	if (!token) {
 		m_log.Emsg("Stat", "Failed to get transfer token");
 		return -ENOENT;
 	}
 
-	HTTPDownload statCommand(getStatUrl(relative_path), "", m_log, token);
+	HTTPDownload statCommand(getStatUrl(*route, relative_path), "", m_log, token);
 	if (!statCommand.SendRequest(0, 0)) {
 		return HTTPRequest::HandleHTTPError(statCommand, m_log, "GET", "");
 	}
@@ -254,13 +319,18 @@ int GlobusFileSystem::Mkdir(const char *path, mode_t mode, int mkpath,
 		return -ENOENT;
 	}
 
-	auto token = getTransferToken();
+	const GlobusRouteConfig *route = nullptr;
+	std::string relative_path;
+	int rv = ResolvePath(path, route, relative_path);
+	if (rv != 0) {
+		return rv;
+	}
+
+	auto token = route->transfer_token.get();
 	if (!token) {
 		m_log.Emsg("Mkdir", "Failed to get transfer token");
 		return -ENOENT;
 	}
-
-	std::string relative_path = extractRelativePath(path);
 	if (relative_path.empty()) {
 		relative_path = "/";
 	}
@@ -276,9 +346,9 @@ int GlobusFileSystem::Mkdir(const char *path, mode_t mode, int mkpath,
 	// anywhere in the path. In this case, it returns HTTP code 404
 
 	if (!mkpath) {
-		GlobusMkdirRequest mkdirCommand(getMkdirUrl(), m_log, token);
+		GlobusMkdirRequest mkdirCommand(getMkdirUrl(*route), m_log, token);
 		nlohmann::json body = {{"DATA_TYPE", "mkdir"},
-							   {"path", buildEndpointPath(relative_path)}};
+							   {"path", buildEndpointPath(*route, relative_path)}};
 		if (!mkdirCommand.SendRequest(body.dump())) {
 			unsigned long httpCode = mkdirCommand.getResponseCode();
 			// Globus mkdir semantics: 202 = success, 502 = exists, 403 = perms,
@@ -326,7 +396,7 @@ int GlobusFileSystem::Mkdir(const char *path, mode_t mode, int mkpath,
 	int first_missing_idx = 0;
 	for (int idx = static_cast<int>(prefixes.size()) - 1; idx >= 0; --idx) {
 		struct stat sb;
-		int stat_rv = Stat((m_storage_prefix + prefixes[idx]).c_str(), &sb, 0, env);
+		int stat_rv = Stat((route->storage_prefix + prefixes[idx]).c_str(), &sb, 0, env);
 		if (stat_rv == 0) {
 			if (!S_ISDIR(sb.st_mode)) {
 				return -ENOTDIR;
@@ -343,9 +413,9 @@ int GlobusFileSystem::Mkdir(const char *path, mode_t mode, int mkpath,
 	// EEXIST if another writer creates a directory between our Stat and Mkdir.
 	for (int idx = first_missing_idx;
 		 idx < static_cast<int>(prefixes.size()); ++idx) {
-		GlobusMkdirRequest mkdirCommand(getMkdirUrl(), m_log, token);
+		GlobusMkdirRequest mkdirCommand(getMkdirUrl(*route), m_log, token);
 		nlohmann::json body = {{"DATA_TYPE", "mkdir"},
-							   {"path", buildEndpointPath(prefixes[idx])}};
+							   {"path", buildEndpointPath(*route, prefixes[idx])}};
 		int rv = 0;
 		if (!mkdirCommand.SendRequest(body.dump())) {
 			unsigned long httpCode = mkdirCommand.getResponseCode();
@@ -371,22 +441,25 @@ int GlobusFileSystem::Mkdir(const char *path, mode_t mode, int mkpath,
 }
 
 const std::string
-GlobusFileSystem::getLsUrl(const std::string &relative_path) const {
-	return getOperationUrl("ls", relative_path);
+GlobusFileSystem::getLsUrl(const GlobusRouteConfig &route,
+						   const std::string &relative_path) const {
+	return getOperationUrl(route, "ls", relative_path);
 }
 
 const std::string
-GlobusFileSystem::getStatUrl(const std::string &relative_path) const {
-	return getOperationUrl("stat", relative_path);
+GlobusFileSystem::getStatUrl(const GlobusRouteConfig &route,
+							 const std::string &relative_path) const {
+	return getOperationUrl(route, "stat", relative_path);
 }
 
-const std::string GlobusFileSystem::getMkdirUrl() const {
-	return getOperationUrl("mkdir");
+const std::string GlobusFileSystem::getMkdirUrl(const GlobusRouteConfig &route) const {
+	return getOperationUrl(route, "mkdir");
 }
 
 std::string
-GlobusFileSystem::buildEndpointPath(const std::string &relative_path) const {
-	std::string endpoint = m_endpoint_path.empty() ? "/" : m_endpoint_path;
+GlobusFileSystem::buildEndpointPath(const GlobusRouteConfig &route,
+									const std::string &relative_path) const {
+	std::string endpoint = route.endpoint_path.empty() ? "/" : route.endpoint_path;
 	if (endpoint[0] != '/') {
 		endpoint = "/" + endpoint;
 	}
@@ -412,14 +485,23 @@ GlobusFileSystem::buildEndpointPath(const std::string &relative_path) const {
 }
 
 const std::string
-GlobusFileSystem::getOperationUrl(const std::string &operation,
+GlobusFileSystem::getOperationUrl(const GlobusRouteConfig &route,
+								  const std::string &operation,
 								  const std::string &relative_path) const {
-	if (m_transfer_url.empty()) {
+	if (route.transfer_url.empty()) {
 		return "";
 	}
 
-	size_t format_pos = m_transfer_url.find("%s");
-	std::string result = m_transfer_url;
+	std::string transfer_url = route.transfer_url;
+	if (!route.endpoint_path.empty()) {
+		std::string ep = route.endpoint_path;
+		if (!ep.empty() && ep.back() == '/') {
+			ep.pop_back();
+		}
+		transfer_url += "/%s?path=" + ep;
+	}
+	size_t format_pos = transfer_url.find("%s");
+	std::string result = transfer_url;
 	result.replace(format_pos, 2, operation);
 
 	// Append the relative path to the URL
@@ -429,23 +511,6 @@ GlobusFileSystem::getOperationUrl(const std::string &operation,
 
 	return result;
 }
-
-std::string
-GlobusFileSystem::extractRelativePath(const std::string &path) const {
-	std::string relative_path = "/";
-
-	if (!m_storage_prefix.empty() && path.find(m_storage_prefix) == 0) {
-		relative_path = path.substr(m_storage_prefix.length());
-		if (relative_path.empty()) {
-			relative_path = "/";
-		} else if (relative_path[0] != '/') {
-			relative_path = "/" + relative_path;
-		}
-	}
-
-	return relative_path;
-}
-
 time_t GlobusFileSystem::parseTimestamp(const std::string &last_modified) {
 	if (!last_modified.empty()) {
 		struct tm tm_time = {};

--- a/src/GlobusFileSystem.hh
+++ b/src/GlobusFileSystem.hh
@@ -24,11 +24,19 @@
 #include <XrdOuc/XrdOucStream.hh>
 #include <XrdSys/XrdSysError.hh>
 
+#include <map>
 #include <memory>
 #include <string>
 
 class GlobusFileSystem : public XrdOssWrapper {
   public:
+	struct GlobusRouteConfig {
+		std::string storage_prefix;
+		std::string endpoint_path;
+		std::string transfer_url;
+		std::shared_ptr<TokenFile> transfer_token;
+	};
+
 	GlobusFileSystem(XrdOss *oss, XrdSysLogger *lp, const char *configfn,
 					 XrdOucEnv *envP);
 	virtual ~GlobusFileSystem();
@@ -78,14 +86,16 @@ class GlobusFileSystem : public XrdOssWrapper {
 	}
 	int Unlink(const char *path, int Opts = 0, XrdOucEnv *env = 0) override;
 
-	// Getters for Globus-specific configuration
-	const std::string &getStoragePrefix() const { return m_storage_prefix; }
-	const TokenFile *getTransferToken() const { return &m_transfer_token; }
+	int ResolvePath(const std::string &path, const GlobusRouteConfig *&route,
+					std::string &relative_path) const;
+	size_t GetRouteCount() const { return m_routes.size(); }
 
 	// Methods to get operation-specific URLs
-	const std::string getLsUrl(const std::string &relative_path = "") const;
-	const std::string getStatUrl(const std::string &relative_path = "") const;
-	const std::string getMkdirUrl() const;
+	const std::string getLsUrl(const GlobusRouteConfig &route,
+							   const std::string &relative_path = "") const;
+	const std::string getStatUrl(const GlobusRouteConfig &route,
+								 const std::string &relative_path = "") const;
+	const std::string getMkdirUrl(const GlobusRouteConfig &route) const;
 
 	// Static utility method for parsing timestamps
 	static time_t parseTimestamp(const std::string &last_modified);
@@ -97,20 +107,15 @@ class GlobusFileSystem : public XrdOssWrapper {
 
   private:
 	const std::string
-	getOperationUrl(const std::string &operation,
+	getOperationUrl(const GlobusRouteConfig &route,
+					const std::string &operation,
 					const std::string &relative_path = "") const;
 	
-	std::string buildEndpointPath(const std::string &relative_path) const;
-
-	// Extract the relative path by removing the storage prefix
-	std::string extractRelativePath(const std::string &path) const;
+	std::string buildEndpointPath(const GlobusRouteConfig &route,
+								  const std::string &relative_path) const;
 
 	XrdOss *m_oss;
 	XrdSysError m_log;
 
-	// Globus-specific configuration
-	std::string m_transfer_url;
-	std::string m_storage_prefix;
-	std::string m_endpoint_path;
-	TokenFile m_transfer_token;
+	std::map<std::string, std::shared_ptr<GlobusRouteConfig>> m_routes;
 };

--- a/src/HTTPDirectory.cc
+++ b/src/HTTPDirectory.cc
@@ -163,19 +163,9 @@ int HTTPDirectory::Readdir(char *buff, int blen) {
 
 int HTTPDirectory::Opendir(const char *path, XrdOucEnv &env) {
 	m_log.Log(LogMask::Debug, "HTTPDirectory::Opendir", "Opendir called");
-	auto configured_hostname = m_oss.getHTTPHostName();
-	auto configured_hostUrl = m_oss.getHTTPHostUrl();
-	const auto &configured_url_base = m_oss.getHTTPUrlBase();
-	if (!configured_url_base.empty()) {
-		configured_hostUrl = configured_url_base;
-		configured_hostname = m_oss.getStoragePrefix();
-	}
-
-	//
-	// Check the path for validity.
-	//
+	const HTTPFileSystem::HTTPRouteConfig *route = nullptr;
 	std::string object;
-	int rv = parse_path(m_oss.getHTTPHostName(), path, object);
+	int rv = m_oss.ResolvePath(path, route, object);
 
 	if (rv != 0) {
 		return rv;
@@ -183,11 +173,13 @@ int HTTPDirectory::Opendir(const char *path, XrdOucEnv &env) {
 
 	if (m_remoteList.empty()) {
 		m_log.Log(LogMask::Debug, "HTTPFile::Opendir", "Opendir called");
-		HTTPList list(configured_hostUrl, object, m_log, m_oss.getToken());
+		std::string configured_hostUrl =
+			!route->url_base.empty() ? route->url_base : route->host_url;
+		HTTPList list(configured_hostUrl, object, m_log, route->token.get());
 		m_log.Log(LogMask::Debug, "HTTPDirectory::Opendir",
 				  "About to perform download from HTTPDirectory::Opendir(): "
 				  "hostname / object:",
-				  configured_hostname.c_str(), object.c_str());
+				  route->matchPrefix().c_str(), object.c_str());
 		if (!list.SendRequest()) {
 			std::stringstream ss;
 			ss << "Failed to send GetObject command: " << list.getResponseCode()

--- a/src/HTTPFile.cc
+++ b/src/HTTPFile.cc
@@ -91,27 +91,18 @@ int HTTPFile::Open(const char *path, int Oflag, mode_t Mode, XrdOucEnv &env) {
 		}
 	}
 
-	auto configured_hostname = m_oss->getHTTPHostName();
-	auto configured_hostUrl = m_oss->getHTTPHostUrl();
-	const auto &configured_url_base = m_oss->getHTTPUrlBase();
-	if (!configured_url_base.empty()) {
-		configured_hostUrl = configured_url_base;
-		configured_hostname = m_oss->getStoragePrefix();
-	}
-
-	//
-	// Check the path for validity.
-	//
+	const HTTPFileSystem::HTTPRouteConfig *route = nullptr;
 	std::string object;
-	int rv = parse_path(configured_hostname, path, object);
+	int rv = m_oss->ResolvePath(path, route, object);
 
 	if (rv != 0) {
 		return rv;
 	}
 
 	m_object = object;
-	m_hostname = configured_hostname;
-	m_hostUrl = configured_hostUrl;
+	m_hostname = route->matchPrefix();
+	m_hostUrl = !route->url_base.empty() ? route->url_base : route->host_url;
+	m_token = route->token.get();
 
 	if ((Oflag & O_ACCMODE) == O_RDONLY) {
 		struct stat buf;
@@ -136,7 +127,7 @@ ssize_t HTTPFile::Read(void *buffer, off_t offset, size_t size) {
 		m_log.Log(LogMask::Warning, "HTTPFile::Read", "File not open");
 		return -EBADF;
 	}
-	HTTPDownload download(m_hostUrl, m_object, m_log, m_oss->getToken());
+	HTTPDownload download(m_hostUrl, m_object, m_log, m_token);
 	m_log.Log(
 		LogMask::Debug, "HTTPFile::Read",
 		"About to perform download from HTTPFile::Read(): hostname / object:",
@@ -176,7 +167,7 @@ int HTTPFile::Fstat(struct stat *buff) {
 	m_log.Log(LogMask::Debug, "HTTPFile::Fstat",
 			  "About to perform HTTPFile::Fstat():", m_hostUrl.c_str(),
 			  m_object.c_str());
-	HTTPHead head(m_hostUrl, m_object, m_log, m_oss->getToken());
+	HTTPHead head(m_hostUrl, m_object, m_log, m_token);
 
 	if (!head.SendRequest()) {
 		// SendRequest() returns false for all errors, including ones
@@ -265,7 +256,7 @@ ssize_t HTTPFile::Write(const void *buffer, off_t offset, size_t size) {
 
 	// Small object optimization as in S3File::Write()
 	if (!m_write_offset && m_object_size == static_cast<off_t>(size)) {
-		HTTPUpload upload(m_hostUrl, m_object, m_log, m_oss->getToken());
+		HTTPUpload upload(m_hostUrl, m_object, m_log, m_token);
 		std::string payload((char *)buffer, size);
 		if (!upload.SendRequest(payload)) {
 			return HTTPRequest::HandleHTTPError(upload, m_log, "PUT",
@@ -288,7 +279,7 @@ ssize_t HTTPFile::Write(const void *buffer, off_t offset, size_t size) {
 			return -EIO;
 		}
 		m_write_op.reset(
-			new HTTPUpload(m_hostUrl, m_object, m_log, m_oss->getToken()));
+			new HTTPUpload(m_hostUrl, m_object, m_log, m_token));
 		std::string payload((char *)buffer, size);
 		if (!m_write_op->StartStreamingRequest(payload, m_object_size)) {
 			return HTTPRequest::HandleHTTPError(
@@ -334,7 +325,7 @@ int HTTPFile::Close(long long *retsz) {
 	// If we opened the object in write mode but did not actually write
 	// anything, make a quick zero-length file.
 	if (m_write && !m_write_offset) {
-		HTTPUpload upload(m_hostUrl, m_object, m_log, m_oss->getToken());
+		HTTPUpload upload(m_hostUrl, m_object, m_log, m_token);
 		if (!upload.SendRequest("")) {
 			return HTTPRequest::HandleHTTPError(
 				upload, m_log, "PUT zero-length", m_object.c_str());

--- a/src/HTTPFile.hh
+++ b/src/HTTPFile.hh
@@ -103,6 +103,7 @@ class HTTPFile : public XrdOssDF {
 	std::string m_hostname;
 	std::string m_hostUrl;
 	std::string m_object;
+	const TokenFile *m_token{nullptr};
 	// Whether the file was opened in write mode
 	bool m_write{false};
 	// Whether the file is open

--- a/src/HTTPFileSystem.cc
+++ b/src/HTTPFileSystem.cc
@@ -40,9 +40,43 @@
 
 using namespace XrdHTTPServer;
 
+namespace {
+
+std::string normalize_http_prefix(const std::string &prefix) {
+	if (prefix.empty() || prefix[0] == '/') {
+		return prefix;
+	}
+	return "/" + prefix;
+}
+
+bool validate_http_route(XrdSysError &log,
+						 const HTTPFileSystem::HTTPRouteConfig &route) {
+	if (route.url_base.empty()) {
+		if (route.host_name.empty()) {
+			log.Emsg("Config", "httpserver.host_name not specified; this or "
+							 "httpserver.url_base are required");
+			return false;
+		}
+		if (route.host_url.empty()) {
+			log.Emsg("Config", "httpserver.host_url not specified; this or "
+							 "httpserver.url_base are required");
+			return false;
+		}
+	}
+	if (route.remote_flavor != "http" && route.remote_flavor != "webdav" &&
+		route.remote_flavor != "auto") {
+		log.Emsg("Config", "Invalid httpserver.remote_flavor specified; "
+						 "must be one of: 'http', 'webdav', or 'auto'");
+		return false;
+	}
+	return true;
+}
+
+} // namespace
+
 HTTPFileSystem::HTTPFileSystem(XrdSysLogger *lp, const char *configfn,
 							   XrdOucEnv * /*envP*/)
-	: m_log(lp, "httpserver_"), m_token("", &m_log) {
+	: m_log(lp, "httpserver_") {
 	m_log.Say("------ Initializing the HTTP filesystem plugin.");
 	if (!Config(lp, configfn)) {
 		throw std::runtime_error("Failed to configure HTTP filesystem plugin.");
@@ -74,8 +108,6 @@ bool HTTPFileSystem::handle_required_config(const std::string &name_from_config,
 }
 
 bool HTTPFileSystem::Config(XrdSysLogger *lp, const char *configfn) {
-	m_remote_flavor = "auto";
-
 	XrdOucEnv myEnv;
 	XrdOucGatherConf httpserver_conf("httpserver.", &m_log);
 	int result;
@@ -85,8 +117,11 @@ bool HTTPFileSystem::Config(XrdSysLogger *lp, const char *configfn) {
 		return false;
 	}
 
-	std::string attribute;
-	std::string token_file;
+	bool saw_blocks = false;
+	bool in_block = false;
+	HTTPRouteConfig default_route;
+	default_route.remote_flavor = "auto";
+	std::shared_ptr<HTTPRouteConfig> route(new HTTPRouteConfig(default_route));
 
 	m_log.setMsgMask(0);
 
@@ -99,51 +134,105 @@ bool HTTPFileSystem::Config(XrdSysLogger *lp, const char *configfn) {
 			continue;
 		}
 
+		if (!strcmp(attribute, "httpserver.begin")) {
+			if (in_block) {
+				m_log.Emsg("Config", "Nested httpserver.begin blocks are not allowed");
+				return false;
+			}
+			in_block = true;
+			saw_blocks = true;
+			route.reset(new HTTPRouteConfig(default_route));
+			continue;
+		}
+		if (!strcmp(attribute, "httpserver.end")) {
+			if (!in_block) {
+				m_log.Emsg("Config", "Encountered httpserver.end without matching begin");
+				return false;
+			}
+			route->storage_prefix = normalize_http_prefix(route->storage_prefix);
+			if (!validate_http_route(m_log, *route)) {
+				return false;
+			}
+			auto prefix = route->matchPrefix();
+			if (prefix.empty()) {
+				m_log.Emsg("Config", "httpserver route prefix must not be empty");
+				return false;
+			}
+			m_routes[prefix] = route;
+			in_block = false;
+			continue;
+		}
+
 		auto value = httpserver_conf.GetToken();
 		if (!value) {
 			continue;
 		}
 
+		auto &target = in_block ? *route : default_route;
+
 		if (!handle_required_config(attribute, "httpserver.host_name", value,
-									http_host_name) ||
+									target.host_name) ||
 			!handle_required_config(attribute, "httpserver.host_url", value,
-									http_host_url) ||
+									target.host_url) ||
 			!handle_required_config(attribute, "httpserver.url_base", value,
-									m_url_base) ||
+									target.url_base) ||
 			!handle_required_config(attribute, "httpserver.remote_flavor",
-									value, m_remote_flavor) ||
+									value, target.remote_flavor) ||
 			!handle_required_config(attribute, "httpserver.storage_prefix",
-									value, m_storage_prefix) ||
-			!handle_required_config(attribute, "httpserver.token_file", value,
-									token_file)) {
+									value, target.storage_prefix)) {
 			return false;
+		}
+		if (!strcmp(attribute, "httpserver.token_file")) {
+			target.token = std::make_shared<TokenFile>(value, &m_log);
 		}
 	}
 
-	if (m_url_base.empty()) {
-		if (http_host_name.empty()) {
-			m_log.Emsg("Config", "httpserver.host_name not specified; this or "
-								 "httpserver.url_base are required");
-			return false;
-		}
-		if (http_host_url.empty()) {
-			m_log.Emsg("Config", "httpserver.host_url not specified; this or "
-								 "httpserver.url_base are required");
-			return false;
-		}
-		if (m_remote_flavor != "http" && m_remote_flavor != "webdav" &&
-			m_remote_flavor != "auto") {
-			m_log.Emsg("Config", "Invalid httpserver.remote_flavor specified; "
-								 "must be one of: 'http', 'webdav', or 'auto'");
-			return false;
-		}
+	if (in_block) {
+		m_log.Emsg("Config", "Encountered unterminated httpserver.begin block");
+		return false;
 	}
 
-	if (!token_file.empty()) {
-		m_token = TokenFile(token_file, &m_log);
+	if (!saw_blocks) {
+		auto final_route = std::make_shared<HTTPRouteConfig>(default_route);
+		final_route->storage_prefix = normalize_http_prefix(final_route->storage_prefix);
+		if (!validate_http_route(m_log, *final_route)) {
+			return false;
+		}
+		auto prefix = final_route->matchPrefix();
+		if (prefix.empty()) {
+			m_log.Emsg("Config", "httpserver route prefix must not be empty");
+			return false;
+		}
+		m_routes[prefix] = final_route;
 	}
 
 	return true;
+}
+
+int HTTPFileSystem::ResolvePath(const char *path,
+								const HTTPRouteConfig *&route,
+								std::string &object) const {
+	const HTTPRouteConfig *best_route = nullptr;
+	std::string best_object;
+	size_t best_len = 0;
+	for (const auto &entry : m_routes) {
+		std::string candidate_object;
+		if (parse_path(entry.second->matchPrefix(), path, candidate_object) != 0) {
+			continue;
+		}
+		size_t candidate_len = entry.second->matchPrefix().size();
+		if (!best_route || candidate_len > best_len) {
+			best_route = entry.second.get();
+			best_object = candidate_object;
+			best_len = candidate_len;
+		}
+	}
+	if (!best_route) {
+		return -ENOENT;
+	}
+	route = best_route;
+	object = best_object;
+	return 0;
 }
 
 // Object Allocation Functions
@@ -176,8 +265,8 @@ int HTTPFileSystem::Create(const char *tid, const char *path, mode_t mode,
 						   XrdOucEnv &env, int opts) {
 	// Is path valid?
 	std::string object;
-	std::string hostname = this->getHTTPHostName();
-	int rv = parse_path(hostname, path, object);
+	const HTTPRouteConfig *route = nullptr;
+	int rv = ResolvePath(path, route, object);
 	if (rv != 0) {
 		return rv;
 	}
@@ -195,16 +284,17 @@ int HTTPFileSystem::Unlink(const char *path, int Opts, XrdOucEnv *env) {
 	}
 
 	std::string object;
-	if (parse_path(getStoragePrefix(), path, object) != 0) {
+	const HTTPRouteConfig *route = nullptr;
+	if (ResolvePath(path, route, object) != 0) {
 		m_log.Emsg("Unlink", "Failed to parse path:", path);
 		return -EIO;
 	}
 	// delete the file
 	std::string hostUrl =
-		!getHTTPUrlBase().empty() ? getHTTPUrlBase() : getHTTPHostUrl();
+		!route->url_base.empty() ? route->url_base : route->host_url;
 	m_log.Log(LogMask::Debug, "Unlink", "Object:", object.c_str());
 	m_log.Log(LogMask::Debug, "Unlink", "Host URL:", hostUrl.c_str());
-	HTTPDelete deleteCommand(hostUrl, object, m_log, &m_token);
+	HTTPDelete deleteCommand(hostUrl, object, m_log, route->token.get());
 	if (!deleteCommand.SendRequest()) {
 		return HTTPRequest::HandleHTTPError(deleteCommand, m_log, "DELETE",
 											object.c_str());

--- a/src/HTTPFileSystem.hh
+++ b/src/HTTPFileSystem.hh
@@ -26,11 +26,25 @@
 #include <XrdSys/XrdSysPthread.hh>
 #include <XrdVersion.hh>
 
+#include <map>
 #include <memory>
 #include <string>
 
 class HTTPFileSystem : public XrdOss {
   public:
+	struct HTTPRouteConfig {
+		std::string host_name;
+		std::string host_url;
+		std::string url_base;
+		std::string storage_prefix;
+		std::string remote_flavor;
+		std::shared_ptr<TokenFile> token;
+
+		const std::string &matchPrefix() const {
+			return !storage_prefix.empty() ? storage_prefix : host_name;
+		}
+	};
+
 	HTTPFileSystem(XrdSysLogger *lp, const char *configfn, XrdOucEnv *envP);
 	virtual ~HTTPFileSystem();
 
@@ -100,12 +114,9 @@ class HTTPFileSystem : public XrdOss {
 		return nullptr;
 	}
 
-	const std::string &getHTTPHostName() const { return http_host_name; }
-	const std::string &getHTTPHostUrl() const { return http_host_url; }
-	const std::string &getHTTPUrlBase() const { return m_url_base; }
-	const std::string &getStoragePrefix() const { return m_storage_prefix; }
-	const std::string &getRemoteFlavor() const { return m_remote_flavor; }
-	const TokenFile *getToken() const { return &m_token; }
+	int ResolvePath(const char *path, const HTTPRouteConfig *&route,
+					std::string &object) const;
+	size_t GetRouteCount() const { return m_routes.size(); }
 
   protected:
 	XrdSysError m_log;
@@ -115,11 +126,5 @@ class HTTPFileSystem : public XrdOss {
 								const std::string &source, std::string &target);
 
   private:
-	std::string http_host_name;
-	std::string http_host_url;
-	std::string m_url_base;
-	std::string m_storage_prefix;
-	std::string m_remote_flavor; // http, webdav or auto. auto is currently a
-								 // synonym for webdav
-	TokenFile m_token;
+	std::map<std::string, std::shared_ptr<HTTPRouteConfig>> m_routes;
 };

--- a/test/http_tests.cc
+++ b/test/http_tests.cc
@@ -18,6 +18,7 @@
 
 #include "../src/HTTPCommands.hh"
 #include "../src/HTTPFileSystem.hh"
+#include "../src/GlobusFileSystem.hh"
 
 #include <XrdOuc/XrdOucEnv.hh>
 #include <XrdSys/XrdSysError.hh>
@@ -29,9 +30,11 @@
 #include <algorithm>
 #include <csignal>
 #include <cstring>
+#include <filesystem>
 #include <fcntl.h>
 #include <fstream>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -69,6 +72,137 @@ void parseEnvFile() {
 			g_config_file = val;
 		}
 	}
+}
+
+std::string writeTempConfig(const std::string &contents) {
+	std::string pattern = "/tmp/http-config-XXXXXX";
+	std::vector<char> path(pattern.begin(), pattern.end());
+	path.push_back('\0');
+	int fd = mkstemp(path.data());
+	if (fd == -1) {
+		throw std::runtime_error("failed to create temp config");
+	}
+	FILE *fh = fdopen(fd, "w");
+	if (!fh) {
+		close(fd);
+		throw std::runtime_error("failed to open temp config");
+	}
+	if (fwrite(contents.data(), 1, contents.size(), fh) != contents.size()) {
+		fclose(fh);
+		throw std::runtime_error("failed to write temp config");
+	}
+	fclose(fh);
+	return std::string(path.data());
+}
+
+TEST(TestHTTPFile, TestMultiRouteResolvePath) {
+	const auto cfgPath = writeTempConfig(
+		"httpserver.begin\n"
+		"httpserver.url_base https://root.example\n"
+		"httpserver.storage_prefix /\n"
+		"httpserver.end\n"
+		"httpserver.begin\n"
+		"httpserver.url_base https://foo.example\n"
+		"httpserver.storage_prefix /foo\n"
+		"httpserver.end\n");
+	struct Cleanup {
+		std::string path;
+		~Cleanup() { std::filesystem::remove(path); }
+	} cleanup{cfgPath};
+
+	XrdSysLogger log;
+	HTTPFileSystem fs(&log, cfgPath.c_str(), nullptr);
+	ASSERT_EQ(fs.GetRouteCount(), 2u);
+
+	const HTTPFileSystem::HTTPRouteConfig *route = nullptr;
+	std::string object;
+	ASSERT_EQ(fs.ResolvePath("/foo/bar.txt", route, object), 0);
+	ASSERT_NE(route, nullptr);
+	ASSERT_EQ(route->storage_prefix, "/foo");
+	ASSERT_EQ(route->url_base, "https://foo.example");
+	ASSERT_EQ(object, "bar.txt");
+
+	ASSERT_EQ(fs.ResolvePath("/other.txt", route, object), 0);
+	ASSERT_NE(route, nullptr);
+	ASSERT_EQ(route->storage_prefix, "/");
+	ASSERT_EQ(route->url_base, "https://root.example");
+	ASSERT_EQ(object, "other.txt");
+}
+
+TEST(TestHTTPFile, TestMultiRouteDefaultsOutsideBlocks) {
+	const auto cfgPath = writeTempConfig(
+		"httpserver.trace debug\n"
+		"httpserver.token_file /tmp/shared.token\n"
+		"httpserver.remote_flavor webdav\n"
+		"httpserver.begin\n"
+		"httpserver.url_base https://root.example\n"
+		"httpserver.storage_prefix /\n"
+		"httpserver.end\n"
+		"httpserver.begin\n"
+		"httpserver.url_base https://foo.example\n"
+		"httpserver.storage_prefix /foo\n"
+		"httpserver.end\n");
+	struct Cleanup {
+		std::string path;
+		~Cleanup() { std::filesystem::remove(path); }
+	} cleanup{cfgPath};
+
+	XrdSysLogger log;
+	HTTPFileSystem fs(&log, cfgPath.c_str(), nullptr);
+	ASSERT_EQ(fs.GetRouteCount(), 2u);
+
+	const HTTPFileSystem::HTTPRouteConfig *route = nullptr;
+	std::string object;
+	ASSERT_EQ(fs.ResolvePath("/foo/bar.txt", route, object), 0);
+	ASSERT_NE(route, nullptr);
+	ASSERT_EQ(route->storage_prefix, "/foo");
+	ASSERT_EQ(route->remote_flavor, "webdav");
+	ASSERT_NE(route->token, nullptr);
+
+	ASSERT_EQ(fs.ResolvePath("/other.txt", route, object), 0);
+	ASSERT_NE(route, nullptr);
+	ASSERT_EQ(route->storage_prefix, "/");
+	ASSERT_EQ(route->remote_flavor, "webdav");
+	ASSERT_NE(route->token, nullptr);
+}
+
+TEST(TestGlobusFile, TestMultiRouteDefaultsOutsideBlocks) {
+	const auto cfgPath = writeTempConfig(
+		"globus.trace debug\n"
+		"globus.transfer_url_base https://transfer.example/endpoint/abc123\n"
+		"globus.transfer_token_file /tmp/shared.transfer.token\n"
+		"globus.begin\n"
+		"globus.endpoint_path /foo\n"
+		"globus.storage_prefix /first/ns\n"
+		"globus.end\n"
+		"globus.begin\n"
+		"globus.endpoint_path /bar\n"
+		"globus.storage_prefix /second/ns\n"
+		"globus.end\n");
+	struct Cleanup {
+		std::string path;
+		~Cleanup() { std::filesystem::remove(path); }
+	} cleanup{cfgPath};
+
+	XrdSysLogger log;
+	GlobusFileSystem fs(nullptr, &log, cfgPath.c_str(), nullptr);
+	ASSERT_EQ(fs.GetRouteCount(), 2u);
+
+	const GlobusFileSystem::GlobusRouteConfig *route = nullptr;
+	std::string relative_path;
+	ASSERT_EQ(fs.ResolvePath("/first/ns/file.txt", route, relative_path), 0);
+	ASSERT_NE(route, nullptr);
+	ASSERT_EQ(route->storage_prefix, "/first/ns");
+	ASSERT_EQ(route->endpoint_path, "/foo");
+	ASSERT_EQ(route->transfer_url, "https://transfer.example/endpoint/abc123");
+	ASSERT_NE(route->transfer_token, nullptr);
+
+	ASSERT_EQ(fs.ResolvePath("/second/ns/file.txt", route, relative_path), 0);
+	ASSERT_NE(route, nullptr);
+	ASSERT_EQ(route->storage_prefix, "/second/ns");
+	ASSERT_EQ(route->endpoint_path, "/bar");
+	ASSERT_EQ(route->transfer_url, "https://transfer.example/endpoint/abc123");
+	ASSERT_NE(route->transfer_token, nullptr);
 }
 
 TEST(TestHTTPFile, TestList) {


### PR DESCRIPTION
This is the XRootD side changes necessary to support multiple Globus exports. In particular, it allows multiple exports to be defined in the XRootD config. 

These changes rely on [this PR](https://github.com/PelicanPlatform/pelican/pull/3346) to actually do the work of generating the XRootD config, though it could technically be tested in isolation.