### PR TITLE
Just turn off the s3_Statistics line with a comment

### DIFF
--- a/src/S3File.cc
+++ b/src/S3File.cc
@@ -551,7 +551,9 @@ void S3File::SendStatistics(XrdSysError &log) {
 				"Failed to generate g-stream statistics packet");
 		return;
 	}
+	/* TODO: Disabling this line because it always gets displayed regardless of the log level (#135)
 	log.Log(LogMask::Debug, "Statistics", buf);
+	*/
 	if (m_gstream && !m_gstream->Insert(buf, len + 1)) {
 		log.Log(LogMask::Error, "Statistics",
 				"Failed to send g-stream statistics packet");


### PR DESCRIPTION
This isn't a 'real' fix for #135 but the current behavior is bad enough that we really need this bandaid.
