### PR TITLE
Add WebDAV (PROPFIND) directory listing with OPTIONS auto-detection

### DIFF
--- a/src/HTTPCommands.cc
+++ b/src/HTTPCommands.cc
@@ -435,6 +435,10 @@ bool HTTPRequest::ReleaseHandle(CURL *curl) {
 	curl_easy_setopt(curl, CURLOPT_NOBODY, 0);
 	curl_easy_setopt(curl, CURLOPT_POST, 0);
 	curl_easy_setopt(curl, CURLOPT_UPLOAD, 0);
+	// Custom request verbs (DELETE, PROPFIND, OPTIONS) set
+	// CURLOPT_CUSTOMREQUEST; it must be cleared or it persists on this reused
+	// handle and overrides the method of the next GET/HEAD/PUT that borrows it.
+	curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, nullptr);
 	curl_easy_setopt(curl, CURLOPT_HEADER, 0);
 	curl_easy_setopt(curl, CURLOPT_SSLCERT, nullptr);
 	curl_easy_setopt(curl, CURLOPT_SSLKEY, nullptr);
@@ -551,6 +555,16 @@ bool HTTPRequest::SetupHandle(CURL *curl) {
 
 	if (httpVerb == "DELETE") {
 		rv = curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "DELETE");
+		if (rv != CURLE_OK) {
+			this->errorCode = "E_CURL_LIB";
+			this->errorMessage =
+				"curl_easy_setopt( CURLOPT_CUSTOMREQUEST ) failed.";
+			return false;
+		}
+	}
+
+	if (httpVerb == "PROPFIND" || httpVerb == "OPTIONS") {
+		rv = curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, httpVerb.c_str());
 		if (rv != CURLE_OK) {
 			this->errorCode = "E_CURL_LIB";
 			this->errorMessage =
@@ -901,6 +915,63 @@ bool HTTPDelete::SendRequest() {
 	includeResponseHeader = true;
 	std::string noPayloadAllowed;
 	return SendHTTPRequest(noPayloadAllowed);
+}
+
+// ---------------------------------------------------------------------------
+
+HTTPPropfind::~HTTPPropfind() {}
+
+bool HTTPPropfind::SendRequest(const std::string &depth) {
+	httpVerb = "PROPFIND";
+	headers["Depth"] = depth;
+	// A successful PROPFIND is reported with 207 Multi-Status.  An empty
+	// request body is interpreted by RFC 4918 servers as an `allprop` request.
+	this->expectedResponseCode = {207};
+	std::string noPayloadAllowed;
+	return SendHTTPRequest(noPayloadAllowed);
+}
+
+// ---------------------------------------------------------------------------
+
+HTTPOptions::~HTTPOptions() {}
+
+bool HTTPOptions::SendRequest() {
+	httpVerb = "OPTIONS";
+	this->expectedResponseCode = {200, 204};
+	// Capture the response headers (Allow, DAV) into the result string.
+	includeResponseHeader = true;
+	std::string noPayloadAllowed;
+	return SendHTTPRequest(noPayloadAllowed);
+}
+
+bool HTTPOptions::SupportsPropfind() const {
+	// includeResponseHeader routes the raw response headers into m_result.
+	// Scan them line-by-line for a DAV capability header or a PROPFIND entry
+	// in the Allow header.
+	std::istringstream stream(m_result);
+	std::string line;
+	while (std::getline(stream, line)) {
+		if (!line.empty() && line.back() == '\r') {
+			line.pop_back();
+		}
+		auto colon = line.find(':');
+		if (colon == std::string::npos) {
+			continue;
+		}
+		std::string name = line.substr(0, colon);
+		std::string value = line.substr(colon + 1);
+		std::transform(name.begin(), name.end(), name.begin(), ::tolower);
+		std::transform(value.begin(), value.end(), value.begin(), ::tolower);
+
+		// The presence of a DAV header indicates WebDAV support.
+		if (name == "dav") {
+			return true;
+		}
+		if (name == "allow" && value.find("propfind") != std::string::npos) {
+			return true;
+		}
+	}
+	return false;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/HTTPCommands.hh
+++ b/src/HTTPCommands.hh
@@ -246,7 +246,7 @@ class HTTPRequest {
 	const TokenFile *m_token{nullptr};
 
 	// The following members manage the work queue and workers.
-	static std::once_flag 
+	static std::once_flag
 		m_init_flag; // Flag to ensure we only initialize workers once.
 	static std::shared_ptr<HandlerQueue>
 		m_queue; // Global queue for all HTTP requests to be processed.
@@ -394,6 +394,50 @@ class HTTPDelete final : public HTTPRequest {
 	virtual ~HTTPDelete();
 
 	virtual bool SendRequest();
+
+  protected:
+	std::string object;
+};
+
+// Retrieve a directory listing from a WebDAV server using the PROPFIND verb.
+// A successful request yields a 207 Multi-Status XML body in the result
+// string.
+class HTTPPropfind final : public HTTPRequest {
+  public:
+	HTTPPropfind(const std::string &h, const std::string &o, XrdSysError &log,
+				 const TokenFile *token)
+		: HTTPRequest(h, log, token), object(o) {
+		hostUrl = hostUrl + "/" + object;
+	}
+
+	virtual ~HTTPPropfind();
+
+	// `depth` is the value of the WebDAV Depth header ("0" for the resource
+	// itself, "1" to include its immediate children).
+	virtual bool SendRequest(const std::string &depth = "1");
+
+  protected:
+	std::string object;
+};
+
+// Query a remote server's capabilities using the OPTIONS verb.  Used to
+// discover whether a server supports WebDAV (PROPFIND) for the "auto" flavor.
+class HTTPOptions final : public HTTPRequest {
+  public:
+	HTTPOptions(const std::string &h, const std::string &o, XrdSysError &log,
+				const TokenFile *token)
+		: HTTPRequest(h, log, token), object(o) {
+		hostUrl = hostUrl + "/" + object;
+	}
+
+	virtual ~HTTPOptions();
+
+	virtual bool SendRequest();
+
+	// True if the OPTIONS response advertises support for the WebDAV PROPFIND
+	// verb (via the `Allow` or `DAV` response headers).  Only meaningful after
+	// a successful SendRequest().
+	bool SupportsPropfind() const;
 
   protected:
 	std::string object;

--- a/src/HTTPDirectory.cc
+++ b/src/HTTPDirectory.cc
@@ -31,6 +31,7 @@
 #include <XrdSys/XrdSysError.hh>
 #include <XrdVersion.hh>
 
+#include <cstring>
 #include <curl/curl.h>
 #include <filesystem>
 #include <iostream>
@@ -103,6 +104,13 @@ void HTTPDirectory::parseHTMLToListing(const std::string &htmlContent) {
 			columnIndex++;
 		}
 
+		// XRootD's HTML index appends a trailing '/' to directory names; drop
+		// it so entry names match those returned by the WebDAV listing and by
+		// POSIX readdir.
+		if (!entry.name.empty() && entry.name.back() == '/') {
+			entry.name.pop_back();
+		}
+
 		// Skip adding invalid/empty rows
 		if (entry.name.empty()) {
 			continue;
@@ -124,6 +132,147 @@ void HTTPDirectory::parseHTMLToListing(const std::string &htmlContent) {
 		workingFile.st_dev = 0;
 		workingFile.st_ino = 0;
 		m_remoteList.push_back({entry.name, workingFile});
+	}
+}
+
+namespace {
+
+// tinyxml2 is namespace-unaware, so element names arrive with their XML
+// prefix attached (e.g. "D:response", "lp1:resourcetype").  Return the local
+// name with any "prefix:" stripped.
+std::string localName(const char *name) {
+	std::string s(name ? name : "");
+	auto pos = s.rfind(':');
+	return pos == std::string::npos ? s : s.substr(pos + 1);
+}
+
+// Depth-first search for the first descendant element with the given local
+// name.  Does not consider `root` itself.
+const tinyxml2::XMLElement *findByLocalName(const tinyxml2::XMLElement *root,
+											const std::string &ln) {
+	if (!root) {
+		return nullptr;
+	}
+	for (auto child = root->FirstChildElement(); child != nullptr;
+		 child = child->NextSiblingElement()) {
+		if (localName(child->Name()) == ln) {
+			return child;
+		}
+		if (auto found = findByLocalName(child, ln)) {
+			return found;
+		}
+	}
+	return nullptr;
+}
+
+// Collect every descendant element with the given local name.  A matched
+// element is not descended into (WebDAV <response> elements are never nested).
+void collectByLocalName(const tinyxml2::XMLElement *root, const std::string &ln,
+						std::vector<const tinyxml2::XMLElement *> &out) {
+	if (!root) {
+		return;
+	}
+	for (auto child = root->FirstChildElement(); child != nullptr;
+		 child = child->NextSiblingElement()) {
+		if (localName(child->Name()) == ln) {
+			out.push_back(child);
+		} else {
+			collectByLocalName(child, ln, out);
+		}
+	}
+}
+
+// Strip leading and trailing '/' characters.
+std::string trimSlashes(const std::string &s) {
+	auto begin = s.find_first_not_of('/');
+	if (begin == std::string::npos) {
+		return "";
+	}
+	auto end = s.find_last_not_of('/');
+	return s.substr(begin, end - begin + 1);
+}
+
+// Reduce a WebDAV href to a server-relative path with surrounding slashes
+// removed.  Handles both absolute-path hrefs ("/testdir/file") and full-URL
+// hrefs ("https://host/testdir/file").
+std::string hrefToRelPath(const std::string &href) {
+	std::string path = href;
+	auto scheme = path.find("://");
+	if (scheme != std::string::npos) {
+		auto slash = path.find('/', scheme + 3);
+		path = (slash == std::string::npos) ? "" : path.substr(slash);
+	}
+	return trimSlashes(path);
+}
+
+} // namespace
+
+void HTTPDirectory::parseWebDAVToListing(const std::string &xmlContent,
+										 const std::string &requestObject) {
+	m_remoteList.clear();
+
+	tinyxml2::XMLDocument doc;
+	if (doc.Parse(xmlContent.c_str()) != tinyxml2::XML_SUCCESS) {
+		m_log.Log(LogMask::Warning, "HTTPDirectory",
+				  "Failed to parse WebDAV PROPFIND response");
+		return;
+	}
+
+	const std::string base = trimSlashes(requestObject);
+
+	std::vector<const tinyxml2::XMLElement *> responses;
+	collectByLocalName(doc.RootElement(), "response", responses);
+
+	for (auto response : responses) {
+		auto hrefEl = findByLocalName(response, "href");
+		if (!hrefEl || !hrefEl->GetText()) {
+			continue;
+		}
+		const std::string relPath = hrefToRelPath(hrefEl->GetText());
+
+		// Skip the entry describing the listed collection itself.
+		if (relPath == base) {
+			continue;
+		}
+
+		// The entry name is the final path component.
+		auto slash = relPath.find_last_of('/');
+		std::string name =
+			(slash == std::string::npos) ? relPath : relPath.substr(slash + 1);
+		if (name.empty()) {
+			continue;
+		}
+
+		// A resource is a directory if it carries a <collection/> resourcetype
+		// or an <iscollection> flag set to 1.
+		bool isDir = findByLocalName(response, "collection") != nullptr;
+		if (!isDir) {
+			auto isColl = findByLocalName(response, "iscollection");
+			if (isColl && isColl->GetText() &&
+				std::string(isColl->GetText()) == "1") {
+				isDir = true;
+			}
+		}
+
+		off_t size = 0;
+		if (auto lenEl = findByLocalName(response, "getcontentlength")) {
+			if (lenEl->GetText()) {
+				try {
+					size = static_cast<off_t>(std::stoll(lenEl->GetText()));
+				} catch (const std::exception &) {
+					size = 0;
+				}
+			}
+		}
+
+		struct stat entry;
+		memset(&entry, 0, sizeof(entry));
+		entry.st_mode = isDir ? (0700 | S_IFDIR) : (0600 | S_IFREG);
+		entry.st_size = isDir ? 4096 : size;
+		entry.st_nlink = 1;
+		entry.st_uid = 1;
+		entry.st_gid = 1;
+		m_remoteList.push_back({name, entry});
 	}
 }
 
@@ -161,14 +310,55 @@ int HTTPDirectory::Readdir(char *buff, int blen) {
 	}
 }
 
+int HTTPDirectory::listViaHTTP(const std::string &hostUrl,
+							   const std::string &object) {
+	HTTPList list(hostUrl, object, m_log, m_oss.getToken());
+	m_log.Log(LogMask::Debug, "HTTPDirectory::listViaHTTP",
+			  "Requesting HTML directory listing for object:", object.c_str());
+	if (!list.SendRequest()) {
+		std::stringstream ss;
+		ss << "Failed to send directory GET command: " << list.getResponseCode()
+		   << " '" << list.getResultString() << "'";
+		m_log.Log(LogMask::Warning, "HTTPDirectory::listViaHTTP",
+				  ss.str().c_str());
+		return 0;
+	}
+
+	parseHTMLToListing(extractHTMLTable(list.getResultString()));
+	return 0;
+}
+
+int HTTPDirectory::listViaWebDAV(const std::string &hostUrl,
+								 const std::string &object) {
+	HTTPPropfind propfind(hostUrl, object, m_log, m_oss.getToken());
+	m_log.Log(LogMask::Debug, "HTTPDirectory::listViaWebDAV",
+			  "Requesting WebDAV PROPFIND listing for object:", object.c_str());
+	if (!propfind.SendRequest("1")) {
+		// A 405 means the server does not implement PROPFIND; signal the caller
+		// so it can fall back to an HTML listing.
+		if (propfind.getResponseCode() == 405) {
+			m_log.Log(LogMask::Info, "HTTPDirectory::listViaWebDAV",
+					  "Server rejected PROPFIND (405 Method Not Allowed)");
+			return -ENOTSUP;
+		}
+		std::stringstream ss;
+		ss << "Failed to send PROPFIND command: " << propfind.getResponseCode()
+		   << " '" << propfind.getResultString() << "'";
+		m_log.Log(LogMask::Warning, "HTTPDirectory::listViaWebDAV",
+				  ss.str().c_str());
+		return 0;
+	}
+
+	parseWebDAVToListing(propfind.getResultString(), object);
+	return 0;
+}
+
 int HTTPDirectory::Opendir(const char *path, XrdOucEnv &env) {
 	m_log.Log(LogMask::Debug, "HTTPDirectory::Opendir", "Opendir called");
-	auto configured_hostname = m_oss.getHTTPHostName();
 	auto configured_hostUrl = m_oss.getHTTPHostUrl();
 	const auto &configured_url_base = m_oss.getHTTPUrlBase();
 	if (!configured_url_base.empty()) {
 		configured_hostUrl = configured_url_base;
-		configured_hostname = m_oss.getStoragePrefix();
 	}
 
 	//
@@ -181,24 +371,23 @@ int HTTPDirectory::Opendir(const char *path, XrdOucEnv &env) {
 		return rv;
 	}
 
-	if (m_remoteList.empty()) {
-		m_log.Log(LogMask::Debug, "HTTPFile::Opendir", "Opendir called");
-		HTTPList list(configured_hostUrl, object, m_log, m_oss.getToken());
-		m_log.Log(LogMask::Debug, "HTTPDirectory::Opendir",
-				  "About to perform download from HTTPDirectory::Opendir(): "
-				  "hostname / object:",
-				  configured_hostname.c_str(), object.c_str());
-		if (!list.SendRequest()) {
-			std::stringstream ss;
-			ss << "Failed to send GetObject command: " << list.getResponseCode()
-			   << "'" << list.getResultString() << "'";
-			m_log.Log(LogMask::Warning, "HTTPDirectory::Opendir",
-					  ss.str().c_str());
-			return 0;
-		}
-
-		parseHTMLToListing(extractHTMLTable(list.getResultString()));
+	if (!m_remoteList.empty()) {
+		return 0;
 	}
 
-	return 0;
+	RemoteFlavor flavor = m_oss.getResolvedFlavor();
+	if (flavor == RemoteFlavor::Http) {
+		return listViaHTTP(configured_hostUrl, object);
+	}
+
+	// WebDAV, or "auto" that has not resolved yet: optimistically try PROPFIND
+	// and, when the flavor is still unknown, fall back to an HTML listing if
+	// the server does not support WebDAV.
+	int listrv = listViaWebDAV(configured_hostUrl, object);
+	if (listrv == -ENOTSUP && flavor == RemoteFlavor::Unknown) {
+		m_log.Log(LogMask::Info, "HTTPDirectory::Opendir",
+				  "Falling back to HTML directory listing");
+		return listViaHTTP(configured_hostUrl, object);
+	}
+	return listrv;
 }

--- a/src/HTTPDirectory.hh
+++ b/src/HTTPDirectory.hh
@@ -56,6 +56,22 @@ class HTTPDirectory : public XrdOssDF {
 	void parseHTMLToListing(const std::string &htmlContent);
 	std::string extractHTMLTable(const std::string &htmlContent);
 
+	// Parse a WebDAV PROPFIND (207 Multi-Status) XML document into
+	// m_remoteList.  `requestObject` is the object path that was listed and is
+	// used to drop the collection's own self-entry from the results.
+	void parseWebDAVToListing(const std::string &xmlContent,
+							  const std::string &requestObject);
+
+	// Retrieve the listing for `object` on `hostUrl` via a plain-HTTP GET of
+	// the HTML directory index.  Returns 0 on success (or a soft failure, to
+	// preserve prior behavior).
+	int listViaHTTP(const std::string &hostUrl, const std::string &object);
+
+	// Retrieve the listing for `object` on `hostUrl` via a WebDAV PROPFIND.
+	// Returns 0 on success, -ENOTSUP if the server rejected PROPFIND with 405
+	// (so the caller may fall back to HTTP), or another negative errno.
+	int listViaWebDAV(const std::string &hostUrl, const std::string &object);
+
 	struct stat *mystat;
 	XrdSysError &m_log;
 	HTTPFileSystem &m_oss;

--- a/src/HTTPFileSystem.cc
+++ b/src/HTTPFileSystem.cc
@@ -17,6 +17,7 @@
  ***************************************************************/
 
 #include "HTTPFileSystem.hh"
+#include "HTTPCommands.hh"
 #include "HTTPDirectory.hh"
 #include "HTTPFile.hh"
 #include "logging.hh"
@@ -131,19 +132,87 @@ bool HTTPFileSystem::Config(XrdSysLogger *lp, const char *configfn) {
 								 "httpserver.url_base are required");
 			return false;
 		}
-		if (m_remote_flavor != "http" && m_remote_flavor != "webdav" &&
-			m_remote_flavor != "auto") {
-			m_log.Emsg("Config", "Invalid httpserver.remote_flavor specified; "
-								 "must be one of: 'http', 'webdav', or 'auto'");
-			return false;
-		}
+	}
+
+	if (m_remote_flavor != "http" && m_remote_flavor != "webdav" &&
+		m_remote_flavor != "auto") {
+		m_log.Emsg("Config", "Invalid httpserver.remote_flavor specified; "
+							 "must be one of: 'http', 'webdav', or 'auto'");
+		return false;
 	}
 
 	if (!token_file.empty()) {
 		m_token = TokenFile(token_file, &m_log);
 	}
 
+	// For the "auto" flavor, probe the remote once at startup so the first
+	// directory listing does not pay the OPTIONS round-trip.  A failure here
+	// (e.g. the remote is not yet reachable) is non-fatal: the flavor stays
+	// unknown and is re-probed lazily on the next listing.
+	if (m_remote_flavor == "auto") {
+		maybeProbeFlavor();
+	}
+
 	return true;
+}
+
+RemoteFlavor HTTPFileSystem::detectRemoteFlavor() {
+	std::string hostUrl =
+		!getHTTPUrlBase().empty() ? getHTTPUrlBase() : getHTTPHostUrl();
+
+	HTTPOptions options(hostUrl, "", m_log, &m_token);
+	if (!options.SendRequest()) {
+		m_log.Log(LogMask::Warning, "HTTPFileSystem",
+				  "OPTIONS probe of remote failed; directory-listing flavor "
+				  "remains undetermined");
+		return RemoteFlavor::Unknown;
+	}
+
+	if (options.SupportsPropfind()) {
+		m_log.Log(LogMask::Info, "HTTPFileSystem",
+				  "Remote advertises WebDAV; using PROPFIND for listings");
+		return RemoteFlavor::Webdav;
+	}
+
+	m_log.Log(LogMask::Info, "HTTPFileSystem",
+			  "Remote does not advertise WebDAV; using HTML for listings");
+	return RemoteFlavor::Http;
+}
+
+void HTTPFileSystem::maybeProbeFlavor() {
+	if (m_resolved_flavor.load() != RemoteFlavor::Unknown) {
+		return;
+	}
+
+	std::lock_guard<std::mutex> lock(m_probe_mtx);
+	// Re-check under the lock; another thread may have resolved it.
+	if (m_resolved_flavor.load() != RemoteFlavor::Unknown) {
+		return;
+	}
+
+	auto now = std::chrono::steady_clock::now();
+	if (m_probed_once && (now - m_last_probe) < m_probe_interval) {
+		return;
+	}
+	m_probed_once = true;
+	m_last_probe = now;
+
+	auto detected = detectRemoteFlavor();
+	if (detected != RemoteFlavor::Unknown) {
+		m_resolved_flavor.store(detected);
+	}
+}
+
+RemoteFlavor HTTPFileSystem::getResolvedFlavor() {
+	if (m_remote_flavor == "http") {
+		return RemoteFlavor::Http;
+	}
+	if (m_remote_flavor == "webdav") {
+		return RemoteFlavor::Webdav;
+	}
+	// "auto": consult (and lazily refresh) the probed result.
+	maybeProbeFlavor();
+	return m_resolved_flavor.load();
 }
 
 // Object Allocation Functions

--- a/src/HTTPFileSystem.hh
+++ b/src/HTTPFileSystem.hh
@@ -26,8 +26,18 @@
 #include <XrdSys/XrdSysPthread.hh>
 #include <XrdVersion.hh>
 
+#include <atomic>
+#include <chrono>
 #include <memory>
+#include <mutex>
 #include <string>
+
+// How the remote server's directory listings are retrieved.
+//   Http    - plain GET returning XRootD's HTML directory index.
+//   Webdav  - WebDAV PROPFIND returning a multi-status XML document.
+//   Unknown - not yet determined (the "auto" flavor before/while probing);
+//             callers should optimistically try WebDAV and fall back to HTTP.
+enum class RemoteFlavor { Unknown, Http, Webdav };
 
 class HTTPFileSystem : public XrdOss {
   public:
@@ -107,6 +117,14 @@ class HTTPFileSystem : public XrdOss {
 	const std::string &getRemoteFlavor() const { return m_remote_flavor; }
 	const TokenFile *getToken() const { return &m_token; }
 
+	// Return the resolved remote flavor used to list directories.
+	//
+	// For the explicitly-configured "http"/"webdav" flavors this is a direct
+	// mapping.  For "auto" it reflects the result of an OPTIONS probe; if the
+	// probe has not yet succeeded (e.g. the remote was down at startup) this
+	// returns RemoteFlavor::Unknown and lazily re-probes on a fixed interval.
+	RemoteFlavor getResolvedFlavor();
+
   protected:
 	XrdSysError m_log;
 
@@ -115,11 +133,28 @@ class HTTPFileSystem : public XrdOss {
 								const std::string &source, std::string &target);
 
   private:
+	// Send an OPTIONS request to the remote and classify it as WebDAV-capable
+	// (advertises PROPFIND) or plain HTTP.  Returns RemoteFlavor::Unknown if
+	// the probe could not be completed.
+	RemoteFlavor detectRemoteFlavor();
+
+	// For the "auto" flavor: run detectRemoteFlavor() if the flavor is still
+	// unknown and we have not probed within the retry interval.  Safe to call
+	// concurrently and never throws.
+	void maybeProbeFlavor();
+
 	std::string http_host_name;
 	std::string http_host_url;
 	std::string m_url_base;
 	std::string m_storage_prefix;
-	std::string m_remote_flavor; // http, webdav or auto. auto is currently a
-								 // synonym for webdav
+	std::string m_remote_flavor; // configured flavor: http, webdav or auto
 	TokenFile m_token;
+
+	// Resolved listing flavor; only meaningful (and mutated) for "auto".
+	std::atomic<RemoteFlavor> m_resolved_flavor{RemoteFlavor::Unknown};
+	std::mutex m_probe_mtx; // serializes OPTIONS probes for "auto"
+	bool m_probed_once{false};
+	std::chrono::steady_clock::time_point m_last_probe;
+	// How long to wait before re-probing a remote that was unreachable.
+	static constexpr std::chrono::seconds m_probe_interval{60};
 };

--- a/test/http_tests.cc
+++ b/test/http_tests.cc
@@ -31,12 +31,16 @@
 #include <cstring>
 #include <fcntl.h>
 #include <fstream>
+#include <map>
 #include <memory>
 #include <string>
+#include <sys/stat.h>
 #include <vector>
 
 std::string g_ca_file;
 std::string g_config_file;
+std::string g_config_file_webdav;
+std::string g_config_file_auto;
 std::string g_url;
 
 void parseEnvFile() {
@@ -67,6 +71,10 @@ void parseEnvFile() {
 			g_url = val;
 		} else if (key == "XROOTD_CFG") {
 			g_config_file = val;
+		} else if (key == "XROOTD_CFG_WEBDAV") {
+			g_config_file_webdav = val;
+		} else if (key == "XROOTD_CFG_AUTO") {
+			g_config_file_auto = val;
 		}
 	}
 }
@@ -95,6 +103,99 @@ TEST(TestHTTPFile, TestList) {
 	char buf[255];
 	auto res = fd->Readdir(buf, 255);
 	ASSERT_EQ(res, 15);
+}
+
+// Read an entire directory into a name -> stat map using the OSS interface.
+static std::map<std::string, struct stat>
+listDirectory(HTTPFileSystem &fs, const char *path, XrdOucEnv &env) {
+	std::map<std::string, struct stat> entries;
+	std::unique_ptr<XrdOssDF> fd(fs.newDir());
+	struct stat entryStat;
+	fd->StatRet(&entryStat);
+	if (fd->Opendir(path, env) != 0) {
+		return entries;
+	}
+	char buf[512];
+	while (true) {
+		auto n = fd->Readdir(buf, sizeof(buf));
+		if (n <= 0 || buf[0] == '\0') {
+			break;
+		}
+		// Readdir populates the stat struct registered via StatRet for the
+		// entry it just returned.
+		entries[std::string(buf)] = entryStat;
+	}
+	return entries;
+}
+
+// List a mixed directory (one file, one subdirectory) over the WebDAV
+// (PROPFIND) flavor and verify the entries, their types, and sizes.
+TEST(TestHTTPFile, TestListWebDAV) {
+	ASSERT_FALSE(g_config_file_webdav.empty())
+		<< "webdav config file not provided by the test harness";
+
+	XrdSysLogger log;
+	XrdOucEnv env;
+	HTTPFileSystem fs(&log, g_config_file_webdav.c_str(), &env);
+	ASSERT_EQ(fs.getResolvedFlavor(), RemoteFlavor::Webdav);
+
+	auto entries = listDirectory(fs, "/listdir", env);
+	ASSERT_EQ(entries.size(), 2u);
+	ASSERT_EQ(entries.count("file_a.txt"), 1u);
+	ASSERT_EQ(entries.count("subdir"), 1u);
+
+	EXPECT_TRUE(S_ISREG(entries["file_a.txt"].st_mode));
+	EXPECT_EQ(entries["file_a.txt"].st_size, 10);
+	EXPECT_TRUE(S_ISDIR(entries["subdir"].st_mode));
+}
+
+// A WebDAV listing of a directory containing a single file returns exactly
+// that file (and not the collection's own self-entry).
+TEST(TestHTTPFile, TestListWebDAVSingleFile) {
+	ASSERT_FALSE(g_config_file_webdav.empty());
+
+	XrdSysLogger log;
+	XrdOucEnv env;
+	HTTPFileSystem fs(&log, g_config_file_webdav.c_str(), &env);
+
+	auto entries = listDirectory(fs, "/testdir", env);
+	ASSERT_EQ(entries.size(), 1u);
+	ASSERT_EQ(entries.count("hello_world.txt"), 1u);
+	EXPECT_TRUE(S_ISREG(entries["hello_world.txt"].st_mode));
+	EXPECT_EQ(entries["hello_world.txt"].st_size, 13);
+}
+
+// The "auto" flavor probes the remote with OPTIONS; XRootD advertises WebDAV,
+// so the flavor must resolve to WebDAV and produce the same listing.
+TEST(TestHTTPFile, TestListAuto) {
+	ASSERT_FALSE(g_config_file_auto.empty());
+
+	XrdSysLogger log;
+	XrdOucEnv env;
+	HTTPFileSystem fs(&log, g_config_file_auto.c_str(), &env);
+	// The startup OPTIONS probe should have detected WebDAV support.
+	ASSERT_EQ(fs.getResolvedFlavor(), RemoteFlavor::Webdav);
+
+	auto entries = listDirectory(fs, "/listdir", env);
+	ASSERT_EQ(entries.size(), 2u);
+	ASSERT_EQ(entries.count("file_a.txt"), 1u);
+	ASSERT_EQ(entries.count("subdir"), 1u);
+}
+
+// The explicit "http" flavor lists the same directory via the HTML index; the
+// entries must match those seen over WebDAV.
+TEST(TestHTTPFile, TestListHTTPFlavor) {
+	XrdSysLogger log;
+	XrdOucEnv env;
+	HTTPFileSystem fs(&log, g_config_file.c_str(), &env);
+	ASSERT_EQ(fs.getResolvedFlavor(), RemoteFlavor::Http);
+
+	auto entries = listDirectory(fs, "/listdir", env);
+	ASSERT_EQ(entries.size(), 2u);
+	ASSERT_EQ(entries.count("file_a.txt"), 1u);
+	ASSERT_EQ(entries.count("subdir"), 1u);
+	EXPECT_TRUE(S_ISREG(entries["file_a.txt"].st_mode));
+	EXPECT_TRUE(S_ISDIR(entries["subdir"].st_mode));
 }
 
 TEST(TestHTTPFile, TestXfer) {

--- a/test/xrdhttp-setup.sh
+++ b/test/xrdhttp-setup.sh
@@ -170,6 +170,12 @@ echo "Hello, World" > "$XROOTD_EXPORTDIR/hello_world.txt"
 mkdir "$XROOTD_EXPORTDIR/testdir"
 echo "Hello, World" > "$XROOTD_EXPORTDIR/testdir/hello_world.txt"
 
+# A directory with mixed content (a regular file and a subdirectory) used to
+# exercise directory listing across the http/webdav/auto flavors.
+mkdir -p "$XROOTD_EXPORTDIR/listdir/subdir"
+printf '0123456789' > "$XROOTD_EXPORTDIR/listdir/file_a.txt"
+printf 'nested' > "$XROOTD_EXPORTDIR/listdir/subdir/nested.txt"
+
 # Launch XRootD daemon.
 ASAN_OPTIONS=detect_odr_violation=0 "$XROOTD_BIN" -c "$XROOTD_CONFIG" -l "$BINARY_DIR/tests/$TEST_NAME/server.log" 0<&- >>"$BINARY_DIR/tests/$TEST_NAME/server.log" 2>>"$BINARY_DIR/tests/$TEST_NAME/server.log" &
 XROOTD_PID=$!
@@ -216,12 +222,24 @@ EOF
 
 echo "http server config: $XROOTD_HTTPSERVER_CONFIG"
 
+# Additional plugin configs that differ only in the remote_flavor, used to
+# exercise WebDAV (PROPFIND) listings and the auto-detect path.
+XROOTD_HTTPSERVER_CONFIG_WEBDAV="$XROOTD_CONFIGDIR/xrootd-httpserver-webdav.cfg"
+sed 's/^httpserver.remote_flavor .*/httpserver.remote_flavor webdav/' \
+	"$XROOTD_HTTPSERVER_CONFIG" > "$XROOTD_HTTPSERVER_CONFIG_WEBDAV"
+
+XROOTD_HTTPSERVER_CONFIG_AUTO="$XROOTD_CONFIGDIR/xrootd-httpserver-auto.cfg"
+sed 's/^httpserver.remote_flavor .*/httpserver.remote_flavor auto/' \
+	"$XROOTD_HTTPSERVER_CONFIG" > "$XROOTD_HTTPSERVER_CONFIG_AUTO"
+
 cat > "$BINARY_DIR/tests/$TEST_NAME/setup.sh" <<EOF
 XROOTD_BIN=$XROOTD_BIN
 XROOTD_PID=$XROOTD_PID
 XROOTD_URL=$XROOTD_URL
 X509_CA_FILE=$XROOTD_CONFIGDIR/tlsca.pem
 XROOTD_CFG=$XROOTD_HTTPSERVER_CONFIG
+XROOTD_CFG_WEBDAV=$XROOTD_HTTPSERVER_CONFIG_WEBDAV
+XROOTD_CFG_AUTO=$XROOTD_HTTPSERVER_CONFIG_AUTO
 EOF
 
 echo "Test environment written to $BINARY_DIR/tests/$TEST_NAME/setup.sh"


### PR DESCRIPTION
Implements the WebDAV listing from the stale PR #108. Previously the httpserver.remote_flavor option (http/webdav/auto) was a no-op: Opendir always issued a plain GET and parsed XRootD's HTML directory index, regardless of flavor. This wires the flavor through and makes 'webdav' functional.

- Add HTTPPropfind (PROPFIND, Depth:1, expects 207 Multi-Status) and HTTPOptions (OPTIONS, reads Allow/DAV headers) command classes.
- HTTPDirectory now lists via GET+HTML for the 'http' flavor and via PROPFIND+multistatus-XML for 'webdav'. The multistatus parser is namespace-prefix agnostic (tinyxml2 is not namespace aware), drops the collection's self-entry, and reports type/size per child.
- 'auto' probes the remote with OPTIONS at startup to pick a flavor. The probe is non-fatal (a down remote leaves the flavor unresolved and is re-probed lazily on a 60s interval) and, while unresolved, Opendir optimistically tries PROPFIND and falls back to HTML on a 405.
- Normalize HTML directory entry names to drop XRootD's trailing '/' so http and webdav listings return identical, POSIX-like names.
- Clear CURLOPT_CUSTOMREQUEST in ReleaseHandle so the new custom verbs do not leak onto the next request that reuses a pooled curl handle.
- Test harness exports webdav/auto plugin configs and a mixed-content directory; add tests covering webdav listing, the self-entry exclusion, auto-detection resolving to webdav, and http/webdav name parity.