### PR TITLE
Implement Mkdir in HTTPFileSystem via WebDAV MKCOL

### DIFF
--- a/src/HTTPCommands.cc
+++ b/src/HTTPCommands.cc
@@ -435,7 +435,7 @@ bool HTTPRequest::ReleaseHandle(CURL *curl) {
 	curl_easy_setopt(curl, CURLOPT_NOBODY, 0);
 	curl_easy_setopt(curl, CURLOPT_POST, 0);
 	curl_easy_setopt(curl, CURLOPT_UPLOAD, 0);
-	// Custom request verbs (DELETE, PROPFIND, OPTIONS) set
+	// Custom request verbs (DELETE, PROPFIND, OPTIONS, MKCOL) set
 	// CURLOPT_CUSTOMREQUEST; it must be cleared or it persists on this reused
 	// handle and overrides the method of the next GET/HEAD/PUT that borrows it.
 	curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, nullptr);
@@ -563,7 +563,8 @@ bool HTTPRequest::SetupHandle(CURL *curl) {
 		}
 	}
 
-	if (httpVerb == "PROPFIND" || httpVerb == "OPTIONS") {
+	if (httpVerb == "PROPFIND" || httpVerb == "OPTIONS" ||
+		httpVerb == "MKCOL") {
 		rv = curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, httpVerb.c_str());
 		if (rv != CURLE_OK) {
 			this->errorCode = "E_CURL_LIB";
@@ -972,6 +973,21 @@ bool HTTPOptions::SupportsPropfind() const {
 		}
 	}
 	return false;
+}
+
+// ---------------------------------------------------------------------------
+
+HTTPMkcol::~HTTPMkcol() {}
+
+bool HTTPMkcol::SendRequest() {
+	httpVerb = "MKCOL";
+	// RFC 4918: a successful MKCOL is reported with 201 Created.  XRootD's
+	// XrdHttp also replies 201 when the collection already exists (i.e. the
+	// operation is idempotent) rather than the RFC-mandated 405.
+	this->expectedResponseCode = {201};
+	includeResponseHeader = true;
+	std::string noPayloadAllowed;
+	return SendHTTPRequest(noPayloadAllowed);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/HTTPCommands.hh
+++ b/src/HTTPCommands.hh
@@ -442,3 +442,21 @@ class HTTPOptions final : public HTTPRequest {
   protected:
 	std::string object;
 };
+
+// Create a directory (collection) on the remote server using the WebDAV
+// MKCOL verb.
+class HTTPMkcol final : public HTTPRequest {
+  public:
+	HTTPMkcol(const std::string &h, const std::string &o, XrdSysError &log,
+			  const TokenFile *token)
+		: HTTPRequest(h, log, token), object(o) {
+		hostUrl = hostUrl + "/" + object;
+	}
+
+	virtual ~HTTPMkcol();
+
+	virtual bool SendRequest();
+
+  protected:
+	std::string object;
+};

--- a/src/HTTPFileSystem.cc
+++ b/src/HTTPFileSystem.cc
@@ -254,6 +254,43 @@ int HTTPFileSystem::Create(const char *tid, const char *path, mode_t mode,
 	return 0;
 }
 
+int HTTPFileSystem::Mkdir(const char *path, mode_t mode, int mkpath,
+						  XrdOucEnv *env) {
+	m_log.Log(LogMask::Debug, "Mkdir", "Creating directory", path);
+
+	// Validate and translate the incoming path into the remote object name.
+	std::string object;
+	if (parse_path(getStoragePrefix(), path, object) != 0) {
+		m_log.Emsg("Mkdir", "Failed to parse path:", path);
+		return -EINVAL;
+	}
+
+	std::string hostUrl =
+		!getHTTPUrlBase().empty() ? getHTTPUrlBase() : getHTTPHostUrl();
+	m_log.Log(LogMask::Debug, "Mkdir", "Object:", object.c_str());
+	m_log.Log(LogMask::Debug, "Mkdir", "Host URL:", hostUrl.c_str());
+
+	// Issue a WebDAV MKCOL against the remote server.  XRootD's XrdHttp
+	// creates any missing intermediate parents itself, so the `mkpath`
+	// argument requires no special handling here.
+	HTTPMkcol mkcolCommand(hostUrl, object, m_log, &m_token);
+	if (!mkcolCommand.SendRequest()) {
+		// A 405 (Method Not Allowed) from MKCOL means a non-collection
+		// resource already exists at this path; surface that as EEXIST so
+		// callers can distinguish it from other failures.
+		if (mkcolCommand.getResponseCode() == 405) {
+			m_log.Log(LogMask::Warning, "Mkdir",
+					  "Cannot create directory; a file already exists at path",
+					  path);
+			return -EEXIST;
+		}
+		return HTTPRequest::HandleHTTPError(mkcolCommand, m_log, "MKCOL",
+											object.c_str());
+	}
+
+	return 0;
+}
+
 int HTTPFileSystem::Unlink(const char *path, int Opts, XrdOucEnv *env) {
 	m_log.Log(LogMask::Debug, "Unlink", "Unlinking path", path);
 	// make sure file exists

--- a/src/HTTPFileSystem.hh
+++ b/src/HTTPFileSystem.hh
@@ -64,9 +64,7 @@ class HTTPFileSystem : public XrdOss {
 	int Init(XrdSysLogger *lp, const char *cfn) { return 0; }
 	int Init(XrdSysLogger *lp, const char *cfn, XrdOucEnv *en) { return 0; }
 	int Mkdir(const char *path, mode_t mode, int mkpath = 0,
-			  XrdOucEnv *env = 0) {
-		return -ENOSYS;
-	}
+			  XrdOucEnv *env = 0);
 	int Reloc(const char *tident, const char *path, const char *cgName,
 			  const char *anchor = 0) {
 		return -ENOSYS;

--- a/test/http_tests.cc
+++ b/test/http_tests.cc
@@ -198,6 +198,108 @@ TEST(TestHTTPFile, TestListHTTPFlavor) {
 	EXPECT_TRUE(S_ISDIR(entries["subdir"].st_mode));
 }
 
+// Create a fresh directory and confirm it exists afterwards.
+TEST(TestHTTPFile, TestMkdir) {
+	XrdSysLogger log;
+	XrdOucEnv env;
+	HTTPFileSystem fs(&log, g_config_file.c_str(), &env);
+
+	// The path should not exist before we create it.
+	struct stat si;
+	ASSERT_EQ(fs.Stat("/mkdir_test_dir/", &si, 0, &env), -ENOENT);
+
+	ASSERT_EQ(fs.Mkdir("/mkdir_test_dir", 0755, 0, &env), 0);
+
+	// After creation the path resolves as a directory (the trailing slash
+	// tells the backend to treat it as one).
+	ASSERT_EQ(fs.Stat("/mkdir_test_dir/", &si, 0, &env), 0);
+	ASSERT_TRUE(S_ISDIR(si.st_mode));
+}
+
+// XRootD's MKCOL is idempotent: creating an existing directory succeeds
+// rather than returning an error.
+TEST(TestHTTPFile, TestMkdirAlreadyExists) {
+	XrdSysLogger log;
+	XrdOucEnv env;
+	HTTPFileSystem fs(&log, g_config_file.c_str(), &env);
+
+	ASSERT_EQ(fs.Mkdir("/mkdir_existing_dir", 0755, 0, &env), 0);
+	// Creating it a second time must still succeed.
+	ASSERT_EQ(fs.Mkdir("/mkdir_existing_dir", 0755, 0, &env), 0);
+}
+
+// Attempting to create a directory where a regular file already exists must
+// fail with EEXIST (the server answers MKCOL with 405 Method Not Allowed).
+TEST(TestHTTPFile, TestMkdirOverExistingFile) {
+	XrdSysLogger log;
+	XrdOucEnv env;
+	HTTPFileSystem fs(&log, g_config_file.c_str(), &env);
+
+	// Lay down a regular file first.
+	std::unique_ptr<XrdOssDF> fh(fs.newFile());
+	auto rc = fh->Open("/mkdir_conflict.txt", O_WRONLY | O_CREAT | O_TRUNC,
+					   0644, env);
+	ASSERT_EQ(rc, 0);
+	const char payload[] = "not a directory";
+	ASSERT_EQ(fh->Write(payload, 0, strlen(payload)),
+			  static_cast<ssize_t>(strlen(payload)));
+	ASSERT_EQ(fh->Close(), 0);
+
+	ASSERT_EQ(fs.Mkdir("/mkdir_conflict.txt", 0755, 0, &env), -EEXIST);
+}
+
+// A multi-level path with missing intermediate parents is created in full;
+// XRootD's MKCOL creates the parents on demand.
+TEST(TestHTTPFile, TestMkdirNested) {
+	XrdSysLogger log;
+	XrdOucEnv env;
+	HTTPFileSystem fs(&log, g_config_file.c_str(), &env);
+
+	ASSERT_EQ(fs.Mkdir("/mkdir_parent/child/grandchild", 0755, 1, &env), 0);
+
+	struct stat si;
+	ASSERT_EQ(fs.Stat("/mkdir_parent/child/grandchild/", &si, 0, &env), 0);
+	ASSERT_TRUE(S_ISDIR(si.st_mode));
+	// The intermediate parent must exist as well.
+	ASSERT_EQ(fs.Stat("/mkdir_parent/child/", &si, 0, &env), 0);
+	ASSERT_TRUE(S_ISDIR(si.st_mode));
+}
+
+// End-to-end: a freshly created directory is usable as a container for a
+// file that can subsequently be written and read back.
+TEST(TestHTTPFile, TestMkdirThenWriteFile) {
+	XrdSysLogger log;
+	XrdOucEnv env;
+	HTTPFileSystem fs(&log, g_config_file.c_str(), &env);
+
+	ASSERT_EQ(fs.Mkdir("/mkdir_usable", 0755, 0, &env), 0);
+
+	const char test_data[] = "contents inside a freshly made directory";
+	const size_t data_size = strlen(test_data);
+
+	std::unique_ptr<XrdOssDF> fh(fs.newFile());
+	auto rc = fh->Open("/mkdir_usable/inside.txt", O_WRONLY | O_CREAT | O_TRUNC,
+					   0644, env);
+	ASSERT_EQ(rc, 0);
+	ASSERT_EQ(fh->Write(test_data, 0, data_size),
+			  static_cast<ssize_t>(data_size));
+	ASSERT_EQ(fh->Close(), 0);
+
+	struct stat si;
+	rc = fs.Stat("/mkdir_usable/inside.txt", &si, 0, &env);
+	ASSERT_EQ(rc, 0);
+	ASSERT_EQ(si.st_size, data_size);
+
+	std::unique_ptr<XrdOssDF> read_fh(fs.newFile());
+	ASSERT_EQ(read_fh->Open("/mkdir_usable/inside.txt", O_RDONLY, 0700, env),
+			  0);
+	char read_buf[128];
+	ASSERT_EQ(read_fh->Read(read_buf, 0, data_size),
+			  static_cast<ssize_t>(data_size));
+	ASSERT_EQ(memcmp(read_buf, test_data, data_size), 0);
+	ASSERT_EQ(read_fh->Close(), 0);
+}
+
 TEST(TestHTTPFile, TestXfer) {
 	XrdSysLogger log;
 	HTTPFileSystem fs(&log, g_config_file.c_str(), nullptr);


### PR DESCRIPTION
Implements issue #69 (replacing the stale PR #105). HTTPFileSystem::Mkdir previously returned -ENOSYS; it now issues a WebDAV MKCOL request to the remote server.

- Add an HTTPMkcol command class (MKCOL verb, expects HTTP 201).
- HTTPFileSystem::Mkdir issues the MKCOL and maps a 405 response (a non-collection resource already exists at the path) to -EEXIST. XRootD's XrdHttp treats MKCOL as idempotent (201 when the collection already exists) and creates missing intermediate parents itself, so `mkpath` needs no special handling.
- Fix a latent bug in HTTPRequest::ReleaseHandle: CURLOPT_CUSTOMREQUEST was never cleared, so the custom verb (DELETE, and now MKCOL) leaked onto the next request that reused the pooled curl handle, corrupting a subsequent GET/HEAD/PUT. Reset it alongside the other conditionally-set options.
- Add integration tests covering create, idempotent re-create, conflict with an existing file (-EEXIST), nested creation with missing parents, and an end-to-end create-then-write-and-read-back round trip.