### PR TITLE
Simplify spec file and drop explicit xrootd version dependencies

### DIFF
--- a/rpm/xrootd-s3-http.spec
+++ b/rpm/xrootd-s3-http.spec
@@ -7,10 +7,17 @@ License:        Apache-2.0
 URL:            https://github.com/PelicanPlatform/%{name}
 Source0:        %{url}/archive/refs/tags/v%{version}/%{name}-%{version}.tar.gz
 
+%bcond_with xrootd6
+
+
 BuildRequires: cmake3
 BuildRequires: gcc-c++
 BuildRequires: make
-BuildRequires: xrootd-server-devel
+%if %{with xrootd6}
+BuildRequires: xrootd-server-devel >= 1:6, xrootd-server-devel < 1:7
+%else
+BuildRequires: xrootd-server-devel >= 1:5.9, xrootd-server-devel < 1:6
+%endif
 BuildRequires: libcurl-devel
 BuildRequires: openssl-devel
 BuildRequires: tinyxml2-devel
@@ -54,8 +61,8 @@ rm %{buildroot}%{_libdir}/libXrdPelicanHttpCore.so
 %license LICENSE
 
 %changelog
-* Tue Jul 21 2026 Mátyás Selmeci <mselmeci@wisc.edu> - 0.6.9-2
-- Simplify spec file; drop explicit xrootd version dependencies
+* Fri Jul 24 2026 Mátyás Selmeci <mselmeci@wisc.edu> - 0.6.9-2
+- Simplify spec file
 
 * Mon Jul 13 2026 Mátyás Selmeci <mselmeci@wisc.edu> - 0.6.9-1
 - Add WebDAV (PROPFIND) directory listing with OPTIONS auto-detection

--- a/rpm/xrootd-s3-http.spec
+++ b/rpm/xrootd-s3-http.spec
@@ -1,30 +1,22 @@
 Name:		xrootd-s3-http
 Version:        0.6.9
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        S3/HTTP/Globus filesystem plugins for xrootd
 
 License:        Apache-2.0
 URL:            https://github.com/PelicanPlatform/%{name}
 Source0:        %{url}/archive/refs/tags/v%{version}/%{name}-%{version}.tar.gz
 
-%define xrootd_current_major 5
-%define xrootd_current_minor 7
-%define xrootd_next_major 6
-
 BuildRequires: cmake3
 BuildRequires: gcc-c++
 BuildRequires: make
-BuildRequires: xrootd-server-libs >= 1:%{xrootd_current_major}
-BuildRequires: xrootd-server-libs <  1:%{xrootd_next_major}
-BuildRequires: xrootd-server-devel >= 1:%{xrootd_current_major}
-BuildRequires: xrootd-server-devel <  1:%{xrootd_next_major}
+BuildRequires: xrootd-server-devel
 BuildRequires: libcurl-devel
 BuildRequires: openssl-devel
 BuildRequires: tinyxml2-devel
 BuildRequires: nlohmann-json-devel
 
-Requires: xrootd-server >= 1:%{xrootd_current_major}.%{xrootd_current_minor}
-Requires: xrootd-server <  1:%{xrootd_next_major}.0.0-1
+Requires: xrootd-server
 
 %description
 %{summary}
@@ -46,19 +38,25 @@ Requires: xrootd-server <  1:%{xrootd_next_major}.0.0-1
 rm %{buildroot}%{_libdir}/libXrdPelicanHttpCore.so
 
 %files
+%{_libdir}/libXrdAccDeadlock-*.so
+%{_libdir}/libXrdAccHttpCallout-*.so
 %{_libdir}/libXrdPelicanHttpCore.so.*
-%{_libdir}/libXrdHTTPServer-5.so
-%{_libdir}/libXrdS3-5.so
-%{_libdir}/libXrdOssHttp-5.so
-%{_libdir}/libXrdOssGlobus-5.so
-%{_libdir}/libXrdOssS3-5.so
-%{_libdir}/libXrdOssFilter-5.so
-%{_libdir}/libXrdOssPosc-5.so
-%{_libdir}/libXrdN2NPrefix-5.so
+%{_libdir}/libXrdHTTPServer-*.so
+%{_libdir}/libXrdS3-*.so
+%{_libdir}/libXrdOssDeadlock-*.so
+%{_libdir}/libXrdOssHttp-*.so
+%{_libdir}/libXrdOssGlobus-*.so
+%{_libdir}/libXrdOssS3-*.so
+%{_libdir}/libXrdOssFilter-*.so
+%{_libdir}/libXrdOssPosc-*.so
+%{_libdir}/libXrdN2NPrefix-*.so
 %doc README.md
 %license LICENSE
 
 %changelog
+* Tue Jul 21 2026 Mátyás Selmeci <mselmeci@wisc.edu> - 0.6.9-2
+- Simplify spec file; drop explicit xrootd version dependencies
+
 * Mon Jul 13 2026 Mátyás Selmeci <mselmeci@wisc.edu> - 0.6.9-1
 - Add WebDAV (PROPFIND) directory listing with OPTIONS auto-detection
 - Implement Mkdir in HTTPFileSystem via WebDAV MKCOL


### PR DESCRIPTION
This code builds just fine against XRootD 6 without any build script changes, and the RPM automatic dependency generator picks up the right version of xrootd to install due to the sonames.

Also, we can drop the BuildRequire on xrootd-server-libs, since it's brought in by xrootd-server-devel.

We do need to add globs to the .so files into the file list - they are suffixed with -5 or -6 depending on what version of xrootd they were built with.